### PR TITLE
[#4] Refactor :  엔티티 재설계

### DIFF
--- a/src/main/java/project/newchat/chatroom/domain/ChatRoom.java
+++ b/src/main/java/project/newchat/chatroom/domain/ChatRoom.java
@@ -6,6 +6,7 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 import project.newchat.chatmsg.domain.ChatMsg;
 import project.newchat.user.domain.User;
+import project.newchat.userchatroom.domain.UserChatRoom;
 
 import javax.persistence.*;
 import java.time.LocalDateTime;
@@ -24,13 +25,16 @@ public class ChatRoom {
 
     private String title;
 
-    private boolean isMaster;
 
     private LocalDateTime createdAt;
 
-    @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "user_id")
-    private User user;
+    private LocalDateTime updatedAt;
+
+    private LocalDateTime deletedAt;
+
+
+    @OneToMany(mappedBy = "chatRoom", fetch = FetchType.LAZY)
+    private List<UserChatRoom> userChatRooms;
 
     @OneToMany(mappedBy = "chatRoom", fetch = FetchType.LAZY)
     private List<ChatMsg> chatMsgs;

--- a/src/main/java/project/newchat/user/domain/User.java
+++ b/src/main/java/project/newchat/user/domain/User.java
@@ -6,8 +6,10 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 import project.newchat.chatmsg.domain.ChatMsg;
 import project.newchat.chatroom.domain.ChatRoom;
+import project.newchat.userchatroom.domain.UserChatRoom;
 
 import javax.persistence.*;
+import java.time.LocalDateTime;
 import java.util.List;
 
 @Entity
@@ -27,8 +29,12 @@ public class User {
 
     private String nickname;
 
+    private LocalDateTime createdAt;
+
+    private LocalDateTime updatedAt;
+
     @OneToMany(mappedBy = "user", fetch = FetchType.LAZY)
-    private List<ChatRoom> chatRooms;
+    private List<UserChatRoom> userChatRooms;
 
     @OneToMany(mappedBy = "user", fetch = FetchType.LAZY)
     private List<ChatMsg> chatMsgs;

--- a/src/main/java/project/newchat/userchatroom/domain/UserChatRoom.java
+++ b/src/main/java/project/newchat/userchatroom/domain/UserChatRoom.java
@@ -1,0 +1,31 @@
+package project.newchat.userchatroom.domain;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import project.newchat.chatroom.domain.ChatRoom;
+import project.newchat.user.domain.User;
+
+import javax.persistence.*;
+
+
+@Entity
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class UserChatRoom {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "user_chat_room_id")
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id")
+    private User user;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "chat_room_id")
+    private ChatRoom chatRoom;
+}


### PR DESCRIPTION
- 리뷰를 반영하여 테이블 분리 <br>
USER - CHATROOM 이었던 방식을 USER - USER_CHATROOM - CHATROOM 테이블로 분리하여 관리하기 위함. 
- isMaster 컬럼 삭제