### PR TITLE
[#7] feat : 채팅방 생성, 입장, ChatRoom 수정

### DIFF
--- a/src/main/java/project/newchat/chatroom/controller/ChatRoomController.java
+++ b/src/main/java/project/newchat/chatroom/controller/ChatRoomController.java
@@ -1,0 +1,46 @@
+package project.newchat.chatroom.controller;
+
+import javax.servlet.http.HttpSession;
+import javax.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+import project.newchat.chatroom.controller.request.ChatRoomRequest;
+import project.newchat.chatroom.service.ChatRoomService;
+import project.newchat.common.config.LoginCheck;
+
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/chat")
+public class ChatRoomController {
+  private final ChatRoomService chatRoomService;
+
+  // 방을 만든 사람이 방장임.(roomCreator 지정해주기)
+  // 방제는 2자 이상 validation 걸기
+  @PostMapping("/room")
+  @LoginCheck
+  public ResponseEntity<Object> createRoom(
+      @RequestBody @Valid ChatRoomRequest chatRoomRequest,
+      HttpSession session) {
+    Long userId = (Long) session.getAttribute("user");
+    chatRoomService.createRoom(chatRoomRequest,userId);
+    return ResponseEntity.ok().body("success");
+  }
+
+  // 방의 key를 통해 입장할 수 있어야 함.
+  // 동시성 이슈 체크
+  @PostMapping("/room/join/{roomId}")
+  @LoginCheck
+  public ResponseEntity<Object> joinRoom (
+      @PathVariable Long roomId,
+      HttpSession session) {
+    Long userId = (Long) session.getAttribute("user");
+    chatRoomService.joinRoom(roomId, userId);
+    return ResponseEntity.ok().body("success");
+  }
+}

--- a/src/main/java/project/newchat/chatroom/controller/request/ChatRoomRequest.java
+++ b/src/main/java/project/newchat/chatroom/controller/request/ChatRoomRequest.java
@@ -1,0 +1,25 @@
+package project.newchat.chatroom.controller.request;
+
+import javax.validation.constraints.Max;
+import javax.validation.constraints.NotEmpty;
+import javax.validation.constraints.NotNull;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.hibernate.validator.constraints.Length;
+
+@Getter
+@AllArgsConstructor
+@NoArgsConstructor
+public class ChatRoomRequest {
+
+  @NotEmpty
+  @Length(min = 2, max = 20)
+  private String title;
+
+  @NotNull
+  @Max(8)
+  private Integer userCountMax;
+
+
+}

--- a/src/main/java/project/newchat/chatroom/controller/response/ChatRoomResponse.java
+++ b/src/main/java/project/newchat/chatroom/controller/response/ChatRoomResponse.java
@@ -1,0 +1,5 @@
+package project.newchat.chatroom.controller.response;
+
+public class ChatRoomResponse {
+
+}

--- a/src/main/java/project/newchat/chatroom/domain/ChatRoom.java
+++ b/src/main/java/project/newchat/chatroom/domain/ChatRoom.java
@@ -25,14 +25,13 @@ public class ChatRoom {
 
     private String title;
 
-
     private LocalDateTime createdAt;
 
     private LocalDateTime updatedAt;
 
-    private LocalDateTime deletedAt;
+    private Long roomCreator;
 
-    private String roomCreator;
+    private Integer userCountMax; // 최대 인원 8명
 
 
     @OneToMany(mappedBy = "chatRoom", fetch = FetchType.LAZY)

--- a/src/main/java/project/newchat/chatroom/repository/ChatRoomRepository.java
+++ b/src/main/java/project/newchat/chatroom/repository/ChatRoomRepository.java
@@ -1,0 +1,18 @@
+package project.newchat.chatroom.repository;
+
+import java.util.Optional;
+import javax.persistence.LockModeType;
+import javax.persistence.QueryHint;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Lock;
+import org.springframework.data.jpa.repository.QueryHints;
+import org.springframework.stereotype.Repository;
+import project.newchat.chatroom.domain.ChatRoom;
+
+@Repository
+public interface ChatRoomRepository extends JpaRepository<ChatRoom, Long> {
+
+  @Lock(LockModeType.PESSIMISTIC_WRITE)
+  @QueryHints({@QueryHint(name = "javax.persistence.lock.timeout", value ="1000")})
+  Optional<ChatRoom> findById(Long aLong);
+}

--- a/src/main/java/project/newchat/chatroom/service/ChatRoomService.java
+++ b/src/main/java/project/newchat/chatroom/service/ChatRoomService.java
@@ -1,0 +1,13 @@
+package project.newchat.chatroom.service;
+
+import org.springframework.stereotype.Service;
+import project.newchat.chatroom.controller.request.ChatRoomRequest;
+
+@Service
+public interface ChatRoomService {
+
+
+  void createRoom(ChatRoomRequest chatRoomRequest, Long userId);
+
+  void joinRoom(Long roomId, Long userId);
+}

--- a/src/main/java/project/newchat/chatroom/service/ChatRoomServiceImpl.java
+++ b/src/main/java/project/newchat/chatroom/service/ChatRoomServiceImpl.java
@@ -1,0 +1,81 @@
+package project.newchat.chatroom.service;
+
+
+import java.time.LocalDateTime;
+import java.util.Optional;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import project.newchat.chatroom.controller.request.ChatRoomRequest;
+import project.newchat.chatroom.domain.ChatRoom;
+import project.newchat.chatroom.repository.ChatRoomRepository;
+import project.newchat.common.exception.CustomException;
+import project.newchat.common.type.ErrorCode;
+import project.newchat.user.domain.User;
+import project.newchat.user.repository.UserRepository;
+import project.newchat.user.service.UserService;
+import project.newchat.userchatroom.domain.UserChatRoom;
+import project.newchat.userchatroom.repository.UserChatRoomRepository;
+
+@Service
+@RequiredArgsConstructor
+public class ChatRoomServiceImpl implements ChatRoomService {
+
+  private final ChatRoomRepository chatRoomRepository;
+
+  private final UserRepository userRepository;
+
+  private final UserChatRoomRepository userChatRoomRepository;
+
+  @Override
+  @Transactional
+  public void createRoom(ChatRoomRequest chatRoomRequest, Long userId) {
+    // 유저정보조회
+    User findUser = userRepository.findById(userId)
+        .orElseThrow(() -> new CustomException(ErrorCode.NOT_FOUND_USER));//
+    // chatroom 생성
+    ChatRoom chatRoom = ChatRoom.builder()
+        .roomCreator(findUser.getId())
+        .title(chatRoomRequest.getTitle())
+        .userCountMax(chatRoomRequest.getUserCountMax())
+        .createdAt(LocalDateTime.now())
+        .updatedAt(LocalDateTime.now())
+        .build();
+    ChatRoom save = chatRoomRepository.save(chatRoom);
+
+    // 연관관계 user_chat room 생성
+    UserChatRoom userChatRoom = UserChatRoom.builder()
+        .user(findUser)
+        .chatRoom(save)
+        .build();
+    // save
+    userChatRoomRepository.save(userChatRoom);
+  }
+
+  @Override
+  @Transactional
+  public void joinRoom(Long roomId, Long userId) {
+    // 유저 조회
+    User findUser = userRepository.findById(userId)
+        .orElseThrow(() -> new CustomException(ErrorCode.NOT_FOUND_USER));
+
+    // room 조회
+    ChatRoom chatRoom = chatRoomRepository.findById(roomId)
+        .orElseThrow(() -> new CustomException(ErrorCode.NOT_FOUND_ROOM));
+
+    // user_chatroom 현재 인원 카운트
+    Long currentUserCount = userChatRoomRepository.countByChatRoomId(roomId);
+
+    // chatroom 입장
+    if (currentUserCount >= chatRoom.getUserCountMax()) {
+      throw new CustomException(ErrorCode.ROOM_USER_FULL);
+    }
+
+    UserChatRoom userChatRoom = UserChatRoom.builder()
+        .user(findUser)
+        .chatRoom(chatRoom)
+        .build();
+    userChatRoomRepository.save(userChatRoom);
+
+  }
+}

--- a/src/main/java/project/newchat/common/config/WebSocketConfig.java
+++ b/src/main/java/project/newchat/common/config/WebSocketConfig.java
@@ -1,0 +1,21 @@
+package project.newchat.common.config;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.socket.config.annotation.EnableWebSocket;
+import org.springframework.web.socket.config.annotation.WebSocketConfigurer;
+import org.springframework.web.socket.config.annotation.WebSocketHandlerRegistry;
+import project.newchat.common.handler.ChatWebSocketHandler;
+
+@Configuration
+@RequiredArgsConstructor
+@EnableWebSocket
+public class WebSocketConfig implements WebSocketConfigurer {
+
+  private final ChatWebSocketHandler chatWebSocketHandler;
+
+  @Override
+  public void registerWebSocketHandlers(WebSocketHandlerRegistry registry) {
+    registry.addHandler(chatWebSocketHandler, "/chat").setAllowedOrigins("*");
+  }
+}

--- a/src/main/java/project/newchat/common/handler/ChatWebSocketHandler.java
+++ b/src/main/java/project/newchat/common/handler/ChatWebSocketHandler.java
@@ -1,0 +1,65 @@
+package project.newchat.common.handler;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Component;
+import org.springframework.web.socket.CloseStatus;
+import org.springframework.web.socket.WebSocketHandler;
+import org.springframework.web.socket.WebSocketMessage;
+import org.springframework.web.socket.WebSocketSession;
+
+@Component
+@Slf4j
+public class ChatWebSocketHandler implements WebSocketHandler {
+
+  private List<WebSocketSession> list = new ArrayList<>();
+
+  // 연결이 되었을 때
+  @Override
+  public void afterConnectionEstablished(WebSocketSession session)
+      throws Exception {
+    list.add(session);
+    log.info(session + "의 클라이언트 접속");
+  }
+
+  // 클라이언트로부터 받은 메시지를 처리하는 로직
+  @Override
+  public void handleMessage(WebSocketSession session, WebSocketMessage<?> message)
+      throws Exception {
+    // 메시지 처리 로직
+    String payload = message.getPayload().toString();
+    log.info("전송 메시지 : " + payload);
+    // 받은 메시지 다른 client에게 전달
+    for (WebSocketSession s : list) {
+      try {
+        s.sendMessage(message);
+      } catch (IOException e) {
+        e.printStackTrace();
+      }
+    }
+  }
+
+  //오류 처리 로직을 구현 (네트워크 오류, 프로토콜 오류, 처리 오류... 생각 중)
+  @Override
+  public void handleTransportError(WebSocketSession session, Throwable exception)
+      throws Exception {
+    log.error(exception.getMessage());
+  }
+
+  // 연결 종료되었을 때
+  @Override
+  public void afterConnectionClosed(WebSocketSession session, CloseStatus closeStatus)
+      throws Exception {
+    list.remove(session);
+    log.info(session + "의 클라이언트 접속 해제");
+  }
+
+  //부분 메시지를 지원하는지 여부를 반환 (아직까지는 필요 없으니 false)
+  //대용량(사진이나 동영상 등)이 필요한 경우에는 따로 구현할 필요가 있음.
+  @Override
+  public boolean supportsPartialMessages() {
+    return false;
+  }
+}

--- a/src/main/java/project/newchat/common/handler/GlobalExceptionHandler.java
+++ b/src/main/java/project/newchat/common/handler/GlobalExceptionHandler.java
@@ -1,4 +1,4 @@
-package project.newchat.common.exception;
+package project.newchat.common.handler;
 
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.dao.DataIntegrityViolationException;
@@ -6,6 +6,7 @@ import org.springframework.validation.FieldError;
 import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
+import project.newchat.common.exception.CustomException;
 import project.newchat.dto.ErrorResponse;
 
 import java.util.HashMap;

--- a/src/main/java/project/newchat/common/type/ErrorCode.java
+++ b/src/main/java/project/newchat/common/type/ErrorCode.java
@@ -11,7 +11,10 @@ public enum ErrorCode {
     INTERNAL_SERVER_ERROR("서버 오류입니다."),
     ALREADY_USER_ID("중복된 아이디입니다."),
     INCONSISTENCY_USER_ID_PASSWORD("아이디와 비밀번호 불일치"),
-    NOT_LOGIN("로그인이 되어 있지 않습니다.")
+    NOT_LOGIN("로그인이 되어 있지 않습니다."),
+    NOT_FOUND_USER("유저를 찾을 수 없습니다."),
+    NOT_FOUND_ROOM("이미 삭제된 방이거나 방을 찾을 수 없습니다."),
+    ROOM_USER_FULL("방에 사용자가 다 차 있습니다.");
     ;
 
     private final String description;

--- a/src/main/java/project/newchat/user/domain/User.java
+++ b/src/main/java/project/newchat/user/domain/User.java
@@ -23,6 +23,7 @@ public class User {
     @Column(name = "user_id")
     private Long id;
 
+    @Column(unique = true)
     private String email;
 
     private String password;

--- a/src/main/java/project/newchat/user/service/UserServiceImpl.java
+++ b/src/main/java/project/newchat/user/service/UserServiceImpl.java
@@ -1,5 +1,6 @@
 package project.newchat.user.service;
 
+import java.time.LocalDateTime;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import project.newchat.common.exception.CustomException;
@@ -27,6 +28,7 @@ public class UserServiceImpl implements UserService {
                 .email(user.getEmail())
                 .password(user.getPassword())
                 .nickname(user.getNickname())
+                .createdAt(LocalDateTime.now())
                 .build();
         return userRepository.save(userSave);
     }

--- a/src/main/java/project/newchat/userchatroom/repository/UserChatRoomRepository.java
+++ b/src/main/java/project/newchat/userchatroom/repository/UserChatRoomRepository.java
@@ -1,0 +1,21 @@
+package project.newchat.userchatroom.repository;
+
+import javax.persistence.LockModeType;
+import javax.persistence.QueryHint;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Lock;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.jpa.repository.QueryHints;
+import org.springframework.stereotype.Repository;
+import project.newchat.userchatroom.domain.UserChatRoom;
+
+@Repository
+public interface UserChatRoomRepository extends JpaRepository<UserChatRoom, Long> {
+
+  @Lock(LockModeType.PESSIMISTIC_WRITE)
+  @QueryHints({@QueryHint(name = "javax.persistence.lock.timeout", value = "1000")})
+  Long countByChatRoomId(Long roomId); // 비관적 락
+
+  @Query("select count(*) from UserChatRoom u where u.chatRoom.id = ?1 ")
+  Long countNonLockByChatRoomId(Long roomId); // test 용도
+}

--- a/src/test/java/project/newchat/chatroom/service/ChatRoomServiceImplTest.java
+++ b/src/test/java/project/newchat/chatroom/service/ChatRoomServiceImplTest.java
@@ -1,0 +1,44 @@
+package project.newchat.chatroom.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.transaction.annotation.Transactional;
+import project.newchat.chatroom.controller.request.ChatRoomRequest;
+import project.newchat.user.domain.User;
+import project.newchat.user.domain.request.LoginRequest;
+import project.newchat.user.domain.request.UserRequest;
+import project.newchat.user.service.UserService;
+
+@SpringBootTest
+@Transactional
+class ChatRoomServiceImplTest {
+
+  @Autowired
+  private ChatRoomService chatRoomService;
+
+  @Autowired
+  private UserService userService;
+
+
+  @Test
+  @DisplayName("채팅방 생성")
+  void createRoom_success() {
+    UserRequest userRequest = new UserRequest("test1234@naver.com", "12345", "test");
+    userService.signUp(userRequest);
+
+    LoginRequest loginRequest = new LoginRequest("test1234@naver.com", "12345");
+    User login = userService.login(loginRequest);
+
+    Long id = login.getId();
+
+    ChatRoomRequest chatRoomRequest = new ChatRoomRequest("testTitle", 8);
+    chatRoomService.createRoom(chatRoomRequest, id);
+
+    assertThat(chatRoomRequest.getTitle()).isEqualTo("testTitle");
+    assertThat(chatRoomRequest.getUserCountMax()).isEqualTo(8);
+  }
+}

--- a/src/test/java/project/newchat/chatroom/service/ConcurrencyChatRoomTest.java
+++ b/src/test/java/project/newchat/chatroom/service/ConcurrencyChatRoomTest.java
@@ -1,0 +1,82 @@
+package project.newchat.chatroom.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.stream.IntStream;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.transaction.annotation.Transactional;
+import project.newchat.chatroom.domain.ChatRoom;
+import project.newchat.chatroom.repository.ChatRoomRepository;
+import project.newchat.user.domain.User;
+import project.newchat.user.domain.request.UserRequest;
+import project.newchat.user.service.UserService;
+import project.newchat.userchatroom.repository.UserChatRoomRepository;
+
+@SpringBootTest
+public class ConcurrencyChatRoomTest {
+  ExecutorService executorService;
+  CountDownLatch countDownLatch;
+
+  @BeforeEach
+  void beforeEach() {
+    executorService = Executors.newFixedThreadPool(30);
+    countDownLatch = new CountDownLatch(30);
+  }
+
+  @Autowired
+  private ChatRoomService chatRoomService;
+
+  @Autowired
+  private UserService userService;
+
+  @Autowired
+  private UserChatRoomRepository userChatRoomRepository;
+  @Autowired
+  private ChatRoomRepository chatRoomRepository;
+
+  @Test
+  @DisplayName("채팅방에 최대 정원 8명, 30명 인원 한번에 입장 시도(lock)")
+  void joinRoom_lock_success() throws InterruptedException {
+    // 동시성 체크
+    List<User> users = new ArrayList<>();
+    for (int i = 0; i < 30; i++) {
+      UserRequest user = new UserRequest(i + "아이디", "12345", "test");
+      User user1 = userService.signUp(user);
+      users.add(user1);
+    }
+
+    ChatRoom test = ChatRoom.builder()
+        .roomCreator(1L)
+        .title("test")
+        .userCountMax(8)
+        .build();
+    ChatRoom save = chatRoomRepository.save(test);
+
+    IntStream.range(0, 30).forEach(e -> executorService.submit(() -> {
+      try {
+        // 테스트할코드
+        try {
+          chatRoomService.joinRoom(save.getId(), users.get(e).getId());
+        } catch (Exception ex) {
+          ex.printStackTrace();
+        }
+      } finally {
+        countDownLatch.countDown();
+      }
+    }));
+    countDownLatch.await();
+
+    Long aLong = userChatRoomRepository.countNonLockByChatRoomId(save.getId());
+
+    assertThat(aLong).isEqualTo(8);
+  }
+}


### PR DESCRIPTION
### 변경사항
<!-- 이 PR에서 어떤점들이 변경되었는지 기술해주세요. 가급적이면 as-is, to-be를 활용해서 작성해주세요.  -->
**AS-IS**

- **ChatRoom 에 있던 DeletedAt 컬럼은 삭제**하였습니다. 저의 요구사항으로는 삭제 시에 데이터를 온전히 다 삭제하는 식으로 생각하기에 해당 deletedAt은 삭제해놨습니다. 
- 또한 **roomCreator는 String -> Long 타입으로 변경**했습니다. id 값으로 인식하기 위함입니다. 기존에는 email이나 nickname으로 넣어주려고 생각했으나, 데이터가 많아질 경우 숫자에 비해 데이터를 많이 잡아 먹는다 판단하여 변경하게 되었습니다.
- 채팅방 생성과 입장 구현 
1- 먼저, 채팅방 생성은 채팅방을 생성함과 동시에 입장하게 만들었습니다. 생성한 자는 roomCreator에도 데이터가 넣어짐과 동시에 식별이 가능하게끔 구현했습니다.<br>
2- 채팅방 입장은 동시성을 고려해서 Repository 에서 락을 거는 것(DB)을 선택했습니다.  낙관적, 비관적 락이 있었는데 저는 **비관적 락을 선택했습니다. 이유는 비관적 락 읽기, 쓰기를 지원해 주기에 사용**하였습니다. 하지만 이 방식은 불필요한 곳까지 락을 건다는 게 단점인데, 찾아 보니 나중에 **kafka 같은 메시징 큐**를 이용할 때 이러한 단점들을 보안해줄 수 있다 하여 나중에 다시 한번 더 고려해볼 예정입니다.

- 동시성 테스트 코드에서..<br>
테스트 클래스 상단에 @Transactional이 있을 경우에는 제 의도대로 실행이 되지 않았습니다. (제 생각에는 한 Transaction으로 묶여 있어서 그렇지 않을까 싶습니다.) 그리고 기존에 있던 메서드 (countByChatRoomId)가 lock이 걸려서인지 실행되지 않아 따로 테스트 용도로 쓰일 메서드(countNonLockByChatRoomId)에 쿼리를 작성하여 실행해본 결과 의도대로 실행됐음을 확인했습니다.

**TO-BE**

- 채팅방 목록 조회 (전체 채팅방, 사용자(자신)가 만든 채팅방, 사용자(자신)가 참여한 채팅방)
- 채팅
- 채팅 조회

추가적으로 된다면 채팅방 나가기, 삭제도 같이 할 예정입니다. 간단하지만, postman 에서 WebSocket connect도 연결이 됐음을 확인하였습니다.

### 테스트
<!-- 본 변경사항이 테스트가 되었는지 기술해주세요 --> 
- [x] 테스트 코드
- [x] API 테스트
