### PR TITLE
[#8] 채팅방 관련 조회, 채팅방 나가기, 삭제 기능 추가

### DIFF
--- a/src/main/java/project/newchat/chatmsg/repository/ChatMsgRepository.java
+++ b/src/main/java/project/newchat/chatmsg/repository/ChatMsgRepository.java
@@ -1,0 +1,10 @@
+package project.newchat.chatmsg.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+import project.newchat.chatmsg.domain.ChatMsg;
+
+@Repository
+public interface ChatMsgRepository extends JpaRepository<ChatMsg, Long> {
+
+}

--- a/src/main/java/project/newchat/chatroom/controller/ChatRoomController.java
+++ b/src/main/java/project/newchat/chatroom/controller/ChatRoomController.java
@@ -1,17 +1,24 @@
 package project.newchat.chatroom.controller;
 
+import java.util.List;
 import javax.servlet.http.HttpSession;
 import javax.validation.Valid;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Pageable;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 import project.newchat.chatroom.controller.request.ChatRoomRequest;
+import project.newchat.chatroom.domain.ChatRoom;
+import project.newchat.chatroom.dto.ChatRoomDto;
 import project.newchat.chatroom.service.ChatRoomService;
 import project.newchat.common.config.LoginCheck;
+import project.newchat.userchatroom.domain.UserChatRoom;
 
 
 @RestController
@@ -41,6 +48,52 @@ public class ChatRoomController {
       HttpSession session) {
     Long userId = (Long) session.getAttribute("user");
     chatRoomService.joinRoom(roomId, userId);
+    return ResponseEntity.ok().body("success");
+  }
+  // 전체 리스트
+  @GetMapping("/room")
+  @LoginCheck
+  public ResponseEntity<Object> roomList (
+      Pageable pageable) {
+    List<ChatRoomDto> roomList = chatRoomService.getRoomList(pageable);
+    return ResponseEntity.ok().body(roomList);
+  }
+  // 사용자(자신)가 생성한 방 리스트 조회
+  @GetMapping("/room/creator")
+  @LoginCheck
+  public ResponseEntity<Object> getByUserRoomList(
+      HttpSession session,Pageable pageable) {
+
+    Long userId = (Long) session.getAttribute("user");
+    List<ChatRoomDto> userByRoomList = chatRoomService.getUserByRoomList(userId, pageable);
+    return ResponseEntity.ok().body(userByRoomList);
+  }
+  // 사용자(자신)가 들어가 있는 방 리스트 조회
+  @GetMapping("/room/part")
+  @LoginCheck
+  public ResponseEntity<Object> getByUserRoomPartList(
+      HttpSession session,Pageable pageable) {
+    Long userId = (Long) session.getAttribute("user");
+    List<ChatRoomDto> userByRoomPartList = chatRoomService
+        .getUserByRoomPartList(userId, pageable);
+    return ResponseEntity.ok().body(userByRoomPartList);
+  }
+  // 채팅방 나가기
+  @DeleteMapping("/room/out/{roomId}")
+  @LoginCheck
+  public ResponseEntity<Object> outRoom(
+      @PathVariable Long roomId, HttpSession session) {
+    Long userId = (Long) session.getAttribute("user");
+    chatRoomService.outRoom(userId, roomId);
+    return ResponseEntity.ok().body("success");
+  }
+  // 채팅방 삭제
+  @DeleteMapping("/room/delete/{roomId}")
+  @LoginCheck
+  public ResponseEntity<Object> deleteRoom(
+      @PathVariable Long roomId, HttpSession session) {
+    Long userId = (Long) session.getAttribute("user");
+    chatRoomService.deleteRoom(userId, roomId);
     return ResponseEntity.ok().body("success");
   }
 }

--- a/src/main/java/project/newchat/chatroom/controller/ChatRoomController.java
+++ b/src/main/java/project/newchat/chatroom/controller/ChatRoomController.java
@@ -65,7 +65,7 @@ public class ChatRoomController {
       HttpSession session,Pageable pageable) {
 
     Long userId = (Long) session.getAttribute("user");
-    List<ChatRoomDto> userByRoomList = chatRoomService.getUserByRoomList(userId, pageable);
+    List<ChatRoomDto> userByRoomList = chatRoomService.roomsByCreatorUser(userId, pageable);
     return ResponseEntity.ok().body(userByRoomList);
   }
   // 사용자(자신)가 들어가 있는 방 리스트 조회

--- a/src/main/java/project/newchat/chatroom/controller/response/ChatRoomResponse.java
+++ b/src/main/java/project/newchat/chatroom/controller/response/ChatRoomResponse.java
@@ -1,5 +1,0 @@
-package project.newchat.chatroom.controller.response;
-
-public class ChatRoomResponse {
-
-}

--- a/src/main/java/project/newchat/chatroom/domain/ChatRoom.java
+++ b/src/main/java/project/newchat/chatroom/domain/ChatRoom.java
@@ -39,4 +39,17 @@ public class ChatRoom {
 
     @OneToMany(mappedBy = "chatRoom", fetch = FetchType.LAZY)
     private List<ChatMsg> chatMsgs;
+
+    @Override
+    public String toString() {
+        return "ChatRoom{" +
+            "id=" + id +
+            ", title='" + title + '\'' +
+            ", createdAt=" + createdAt +
+            ", updatedAt=" + updatedAt +
+            ", roomCreator=" + roomCreator +
+            ", userCountMax=" + userCountMax +
+            ", userChatRooms=" + userChatRooms.size() +
+            '}';
+    }
 }

--- a/src/main/java/project/newchat/chatroom/dto/ChatRoomDto.java
+++ b/src/main/java/project/newchat/chatroom/dto/ChatRoomDto.java
@@ -5,6 +5,7 @@ import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
+import project.newchat.chatroom.domain.ChatRoom;
 
 @Getter
 @Setter
@@ -19,4 +20,13 @@ public class ChatRoomDto {
   private Long currentUserCount;
 
   private Integer userCountMax;
+
+  public static ChatRoomDto of(ChatRoom chatRoom) {
+    return ChatRoomDto.builder()
+        .id(chatRoom.getId())
+        .title(chatRoom.getTitle())
+        .currentUserCount((long) chatRoom.getUserChatRooms().size())
+        .userCountMax(chatRoom.getUserCountMax())
+        .build();
+  }
 }

--- a/src/main/java/project/newchat/chatroom/dto/ChatRoomDto.java
+++ b/src/main/java/project/newchat/chatroom/dto/ChatRoomDto.java
@@ -1,0 +1,22 @@
+package project.newchat.chatroom.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class ChatRoomDto {
+  private Long id;
+
+  private String title;
+
+  private Long currentUserCount;
+
+  private Integer userCountMax;
+}

--- a/src/main/java/project/newchat/chatroom/repository/ChatRoomRepository.java
+++ b/src/main/java/project/newchat/chatroom/repository/ChatRoomRepository.java
@@ -26,5 +26,5 @@ public interface ChatRoomRepository extends JpaRepository<ChatRoom, Long> {
   Page<ChatRoom> findAllByUserChatRoomsUserId(Long userId,Pageable pageable);
 
   @Query(value = "SELECT ROOM_CREATOR FROM chat_room WHERE CHAT_ROOM_ID = ?", nativeQuery = true)
-  Long findChatRoomByRoomCreator(Long roomId);
+  Long findChatRoomIdByRoomId(Long roomId);
 }

--- a/src/main/java/project/newchat/chatroom/repository/ChatRoomRepository.java
+++ b/src/main/java/project/newchat/chatroom/repository/ChatRoomRepository.java
@@ -3,9 +3,13 @@ package project.newchat.chatroom.repository;
 import java.util.Optional;
 import javax.persistence.LockModeType;
 import javax.persistence.QueryHint;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Lock;
+import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.jpa.repository.QueryHints;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 import project.newchat.chatroom.domain.ChatRoom;
 
@@ -15,4 +19,12 @@ public interface ChatRoomRepository extends JpaRepository<ChatRoom, Long> {
   @Lock(LockModeType.PESSIMISTIC_WRITE)
   @QueryHints({@QueryHint(name = "javax.persistence.lock.timeout", value ="1000")})
   Optional<ChatRoom> findById(Long aLong);
+
+  @Query("select c from ChatRoom c where c.roomCreator=:userId")
+  Page<ChatRoom> findAllByUserId(@Param("userId")Long userId,Pageable pageable); //
+
+  Page<ChatRoom> findAllByUserChatRoomsUserId(Long userId,Pageable pageable);
+
+  @Query(value = "SELECT ROOM_CREATOR FROM chat_room WHERE CHAT_ROOM_ID = ?", nativeQuery = true)
+  Long findChatRoomByRoomCreator(Long roomId);
 }

--- a/src/main/java/project/newchat/chatroom/service/ChatRoomService.java
+++ b/src/main/java/project/newchat/chatroom/service/ChatRoomService.java
@@ -15,7 +15,7 @@ public interface ChatRoomService {
   List<ChatRoomDto> getRoomList(Pageable pageable);
 
 
-  List<ChatRoomDto> getUserByRoomList(Long userId, Pageable pageable);
+  List<ChatRoomDto> roomsByCreatorUser(Long userId, Pageable pageable);
 
   List<ChatRoomDto> getUserByRoomPartList(Long userId, Pageable pageable);
 

--- a/src/main/java/project/newchat/chatroom/service/ChatRoomService.java
+++ b/src/main/java/project/newchat/chatroom/service/ChatRoomService.java
@@ -1,13 +1,25 @@
 package project.newchat.chatroom.service;
 
-import org.springframework.stereotype.Service;
+import java.util.List;
+import org.springframework.data.domain.Pageable;
 import project.newchat.chatroom.controller.request.ChatRoomRequest;
+import project.newchat.chatroom.dto.ChatRoomDto;
 
-@Service
 public interface ChatRoomService {
 
 
   void createRoom(ChatRoomRequest chatRoomRequest, Long userId);
 
   void joinRoom(Long roomId, Long userId);
+
+  List<ChatRoomDto> getRoomList(Pageable pageable);
+
+
+  List<ChatRoomDto> getUserByRoomList(Long userId, Pageable pageable);
+
+  List<ChatRoomDto> getUserByRoomPartList(Long userId, Pageable pageable);
+
+  void outRoom(Long userId, Long roomId);
+
+  void deleteRoom(Long userId, Long roomId);
 }

--- a/src/main/java/project/newchat/chatroom/service/ChatRoomServiceImpl.java
+++ b/src/main/java/project/newchat/chatroom/service/ChatRoomServiceImpl.java
@@ -7,6 +7,7 @@ import java.util.LinkedList;
 import java.util.List;
 import java.util.Objects;
 import java.util.Optional;
+import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
@@ -97,7 +98,7 @@ public class ChatRoomServiceImpl implements ChatRoomService {
 
   // 자신이 생성한 방 리스트 조회
   @Override
-  public List<ChatRoomDto> getUserByRoomList(Long userId, Pageable pageable) {
+  public List<ChatRoomDto> roomsByCreatorUser(Long userId, Pageable pageable) {
     Page<ChatRoom> all = chatRoomRepository.findAllByUserId(userId, pageable);
     return getChatRoomDtos(all);
   }
@@ -114,7 +115,7 @@ public class ChatRoomServiceImpl implements ChatRoomService {
   @Transactional
   public void outRoom(Long userId, Long roomId) {
     Long roomCreatorId = chatRoomRepository
-        .findChatRoomByRoomCreator(roomId);
+        .findChatRoomIdByRoomId(roomId);
     // 방장이 아니라면
     if (!Objects.equals(roomCreatorId, userId)) {
       userChatRoomRepository.deleteUserChatRoomByUserId(userId);
@@ -129,7 +130,7 @@ public class ChatRoomServiceImpl implements ChatRoomService {
   @Transactional
   public void deleteRoom(Long userId, Long roomId) {
     Long roomCreatorId = chatRoomRepository
-        .findChatRoomByRoomCreator(roomId);
+        .findChatRoomIdByRoomId(roomId);
     if (!Objects.equals(roomCreatorId, userId)) {
       throw new CustomException(ErrorCode.NOT_ROOM_CREATOR);
     }
@@ -141,19 +142,21 @@ public class ChatRoomServiceImpl implements ChatRoomService {
 
   // 방 조회 DTO 변환 메서드 추출
   private static List<ChatRoomDto> getChatRoomDtos(Page<ChatRoom> all) {
-    List<ChatRoomDto> chatRoomList = new ArrayList<>();
-
-    for (ChatRoom list : all) {
-      ChatRoomDto dto = ChatRoomDto.builder()
-          .id(list.getId())
-          .title(list.getTitle())
-          .currentUserCount((long) list.getUserChatRooms().size())
-          .userCountMax(list.getUserCountMax())
-          .build();
-
-      chatRoomList.add(dto);
-    }
-    return chatRoomList;
+//    List<ChatRoomDto> chatRoomList = new ArrayList<>();
+//
+//    for (ChatRoom list : all) {
+//      ChatRoomDto dto = ChatRoomDto.builder()
+//          .id(list.getId())
+//          .title(list.getTitle())
+//          .currentUserCount((long) list.getUserChatRooms().size())
+//          .userCountMax(list.getUserCountMax())
+//          .build();
+//
+//      chatRoomList.add(dto);
+//    }
+//    return chatRoomList;
+    return all.stream()
+        .map(ChatRoomDto::of)
+        .collect(Collectors.toList());
   }
-
 }

--- a/src/main/java/project/newchat/common/type/ErrorCode.java
+++ b/src/main/java/project/newchat/common/type/ErrorCode.java
@@ -14,7 +14,10 @@ public enum ErrorCode {
     NOT_LOGIN("로그인이 되어 있지 않습니다."),
     NOT_FOUND_USER("유저를 찾을 수 없습니다."),
     NOT_FOUND_ROOM("이미 삭제된 방이거나 방을 찾을 수 없습니다."),
-    ROOM_USER_FULL("방에 사용자가 다 차 있습니다.");
+    ROOM_USER_FULL("방에 사용자가 다 차 있습니다."),
+    NONE_ROOM("현재 방이 없습니다."),
+    CHAT_ERROR("채팅이 전송에 오류가 있습니다."),
+    NOT_ROOM_CREATOR("방 생성자가 아닙니다.")
     ;
 
     private final String description;

--- a/src/main/java/project/newchat/userchatroom/repository/UserChatRoomRepository.java
+++ b/src/main/java/project/newchat/userchatroom/repository/UserChatRoomRepository.java
@@ -6,6 +6,7 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Lock;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.jpa.repository.QueryHints;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 import project.newchat.userchatroom.domain.UserChatRoom;
 
@@ -16,6 +17,11 @@ public interface UserChatRoomRepository extends JpaRepository<UserChatRoom, Long
   @QueryHints({@QueryHint(name = "javax.persistence.lock.timeout", value = "1000")})
   Long countByChatRoomId(Long roomId); // 비관적 락
 
-  @Query("select count(*) from UserChatRoom u where u.chatRoom.id = ?1 ")
-  Long countNonLockByChatRoomId(Long roomId); // test 용도
+//  @Query("select count(*) from UserChatRoom u where u.chatRoom.id = ?1 ")
+  @Query("select count(*) from UserChatRoom u where u.chatRoom.id = :roomId")
+  Long countNonLockByChatRoomId(@Param("roomId")Long roomId); // test 용도
+
+  void deleteUserChatRoomByChatRoom_Id(Long chatRoomId);
+
+  void deleteUserChatRoomByUserId(Long userId);
 }


### PR DESCRIPTION
### 변경사항
<!-- 이 PR에서 어떤점들이 변경되었는지 기술해주세요. 가급적이면 as-is, to-be를 활용해서 작성해주세요.  -->
**AS-IS**

- 채팅방 관련 조회 기능 추가되었습니다.
전체 조회, 사용자(자신)가 생성한 방 조회, 참여한 방 조회를 할 수 있습니다.
- 채팅방 나가기, 삭제 기능 추가되었습니다.
채팅방 나가기와 삭제 시 채팅방 생성자의 판별로 방을 삭제하거나 나가거나 할 수 있습니다. 이 부분에 관해서는 추후에 방을 삭제하는 것만이 아닌, 생성자(방장) 권한을 부여할 수 있게끔 추가할 예정입니다. 
아직은 **채팅하기가 구현이 되지 않아 방 삭제 시에 ChatMsg 부분은 삭제를 주석처리 해놓은 상태**입니다. 채팅이 구현되는 시점에 바로 수정하여 다시 올리도록 하겠습니다.
- **WebSocketHandler  부분**
저번에 리뷰 주셨던 핸들러 부분입니다. 이 부분에 관해서는 아직 정리가 되지 않아 PR에 올리지 않았습니다. 다음 PR에 같이 피드백을 수정하여 올려 놓을 예정입니다..!! 
- Controller **Response Custom Class 만들기**
이 부분에 관해서도 다음 PR에 올려 놓도록 하겠습니다..!!

** 저번에 주셨던 피드백 적용하여 올렸습니다. Response 쓰지 않는 클래스 제거

**TO-BE**

- 채팅 구현
- WebSocketHandler 피드백 수정하기
- 중복되는 코드들 간소화, 가독성 올리기
- 코드 컨벤션 적용 안 된 곳은 따로 머지해서 올려 놓기

### 테스트
<!-- 본 변경사항이 테스트가 되었는지 기술해주세요 --> 
- [ ] 테스트 코드
- [x] API 테스트
