### PR TITLE
[#9] feat : ResponseUtils 커스텀 클래스 추가, 채팅방 join Refactor, WebSocket 설정

### DIFF
--- a/src/main/java/project/newchat/chatroom/controller/ChatRoomController.java
+++ b/src/main/java/project/newchat/chatroom/controller/ChatRoomController.java
@@ -18,6 +18,7 @@ import project.newchat.chatroom.domain.ChatRoom;
 import project.newchat.chatroom.dto.ChatRoomDto;
 import project.newchat.chatroom.service.ChatRoomService;
 import project.newchat.common.config.LoginCheck;
+import project.newchat.common.util.ResponseUtils;
 import project.newchat.userchatroom.domain.UserChatRoom;
 
 
@@ -35,8 +36,12 @@ public class ChatRoomController {
       @RequestBody @Valid ChatRoomRequest chatRoomRequest,
       HttpSession session) {
     Long userId = (Long) session.getAttribute("user");
-    chatRoomService.createRoom(chatRoomRequest,userId);
-    return ResponseEntity.ok().body("success");
+    chatRoomService.createRoom(chatRoomRequest, userId);
+    if (userId == null) {
+      return ResponseUtils.badRequest("로그인 후에 이용해 주세요.");
+    } else {
+      return ResponseUtils.ok("채팅방을 생성하였습니다.");
+    }
   }
 
   // 방의 key를 통해 입장할 수 있어야 함.
@@ -48,7 +53,11 @@ public class ChatRoomController {
       HttpSession session) {
     Long userId = (Long) session.getAttribute("user");
     chatRoomService.joinRoom(roomId, userId);
-    return ResponseEntity.ok().body("success");
+    if (userId == null) {
+      return ResponseUtils.badRequest("로그인 후에 이용해 주세요.");
+    } else {
+      return ResponseUtils.ok("해당 채팅방에 입장하였습니다.");
+    }
   }
   // 전체 리스트
   @GetMapping("/room")
@@ -56,7 +65,7 @@ public class ChatRoomController {
   public ResponseEntity<Object> roomList (
       Pageable pageable) {
     List<ChatRoomDto> roomList = chatRoomService.getRoomList(pageable);
-    return ResponseEntity.ok().body(roomList);
+    return ResponseUtils.ok("전체 목록 조회에 성공하였습니다.", roomList);
   }
   // 사용자(자신)가 생성한 방 리스트 조회
   @GetMapping("/room/creator")
@@ -66,7 +75,15 @@ public class ChatRoomController {
 
     Long userId = (Long) session.getAttribute("user");
     List<ChatRoomDto> userByRoomList = chatRoomService.roomsByCreatorUser(userId, pageable);
-    return ResponseEntity.ok().body(userByRoomList);
+
+    if (userId == null) {
+      return ResponseUtils.badRequest("로그인 후에 이용해 주세요.");
+    }
+    if (userByRoomList.size() == 0) {
+      return ResponseUtils.notFound("사용자(자신)가 생성한 방이 없습니다.");
+    } else {
+      return ResponseUtils.ok("사용자(자신)가 생성한 방 리스트 조회 성공", userByRoomList);
+    }
   }
   // 사용자(자신)가 들어가 있는 방 리스트 조회
   @GetMapping("/room/part")
@@ -76,7 +93,13 @@ public class ChatRoomController {
     Long userId = (Long) session.getAttribute("user");
     List<ChatRoomDto> userByRoomPartList = chatRoomService
         .getUserByRoomPartList(userId, pageable);
-    return ResponseEntity.ok().body(userByRoomPartList);
+    if (userId == null) {
+      return ResponseUtils.badRequest("로그인 후에 이용해 주세요.");
+    } if (userByRoomPartList.size() == 0) {
+      return ResponseUtils.notFound("사용자(자신)가 들어가 있는 방이 없습니다.");
+    } else {
+      return ResponseUtils.ok("사용자(자신)가 들어가 있는 방 리스트 조회 성공.", userByRoomPartList);
+    }
   }
   // 채팅방 나가기
   @DeleteMapping("/room/out/{roomId}")
@@ -85,7 +108,11 @@ public class ChatRoomController {
       @PathVariable Long roomId, HttpSession session) {
     Long userId = (Long) session.getAttribute("user");
     chatRoomService.outRoom(userId, roomId);
-    return ResponseEntity.ok().body("success");
+    if (userId == null) {
+      return ResponseUtils.badRequest("로그인 후에 이용해 주세요.");
+    } else {
+      return ResponseUtils.ok("채팅방을 나갔습니다.");
+    }
   }
   // 채팅방 삭제
   @DeleteMapping("/room/delete/{roomId}")
@@ -94,6 +121,10 @@ public class ChatRoomController {
       @PathVariable Long roomId, HttpSession session) {
     Long userId = (Long) session.getAttribute("user");
     chatRoomService.deleteRoom(userId, roomId);
-    return ResponseEntity.ok().body("success");
+    if (userId == null) {
+      return ResponseUtils.badRequest("로그인 후에 이용해 주세요.");
+    } else {
+      return ResponseUtils.ok("채팅방을 삭제했습니다.");
+    }
   }
 }

--- a/src/main/java/project/newchat/chatroom/service/ChatRoomServiceImpl.java
+++ b/src/main/java/project/newchat/chatroom/service/ChatRoomServiceImpl.java
@@ -76,6 +76,13 @@ public class ChatRoomServiceImpl implements ChatRoomService {
     // user_chatroom 현재 인원 카운트
     Long currentUserCount = userChatRoomRepository.countByChatRoomId(roomId);
 
+    List<Long> userChatRoomByChatRoomId = userChatRoomRepository.findUserChatRoomByChatRoom_Id(
+        roomId);
+
+    if (userChatRoomByChatRoomId.contains(userId)) {
+      throw new CustomException(ErrorCode.ALREADY_JOIN_ROOM);
+    }
+
     // chatroom 입장
     if (currentUserCount >= chatRoom.getUserCountMax()) {
       throw new CustomException(ErrorCode.ROOM_USER_FULL);

--- a/src/main/java/project/newchat/common/handler/ChatWebSocketHandler.java
+++ b/src/main/java/project/newchat/common/handler/ChatWebSocketHandler.java
@@ -2,25 +2,37 @@ package project.newchat.common.handler;
 
 import java.io.IOException;
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
+import java.util.Objects;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Component;
 import org.springframework.web.socket.CloseStatus;
 import org.springframework.web.socket.WebSocketHandler;
 import org.springframework.web.socket.WebSocketMessage;
 import org.springframework.web.socket.WebSocketSession;
+import project.newchat.common.exception.CustomException;
+import project.newchat.common.type.ErrorCode;
 
 @Component
 @Slf4j
 public class ChatWebSocketHandler implements WebSocketHandler {
 
-  private List<WebSocketSession> list = new ArrayList<>();
+  private Map<Long, List<WebSocketSession>> chatRooms = new HashMap<>();
+  // 방의 키값
 
   // 연결이 되었을 때
   @Override
   public void afterConnectionEstablished(WebSocketSession session)
       throws Exception {
-    list.add(session);
+    Long roomId = extractRoomId(session);
+    // roomId 가 없을 경우, session list (new ArrayList)
+    List<WebSocketSession> roomSessions = chatRooms.getOrDefault(roomId, new ArrayList<>());
+    // 세션 추가
+    roomSessions.add(session);
+    // 해당 방의 키값에 session list 추가
+    chatRooms.put(roomId, roomSessions);
     log.info(session + "의 클라이언트 접속");
   }
 
@@ -28,16 +40,22 @@ public class ChatWebSocketHandler implements WebSocketHandler {
   @Override
   public void handleMessage(WebSocketSession session, WebSocketMessage<?> message)
       throws Exception {
-    // 메시지 처리 로직
-    String payload = message.getPayload().toString();
-    log.info("전송 메시지 : " + payload);
-    // 받은 메시지 다른 client에게 전달
-    for (WebSocketSession s : list) {
-      try {
-        s.sendMessage(message);
-      } catch (IOException e) {
-        e.printStackTrace();
+    Long roomId = extractRoomId(session);
+    List<WebSocketSession> roomSessions = chatRooms.get(roomId);
+    if (roomSessions != null) {
+      String payload = message.getPayload().toString();
+      log.info("전송 메시지: " + payload);
+
+      for (WebSocketSession msg : roomSessions) {
+        try {
+          msg.sendMessage(message);
+        } catch (IOException e) {
+          throw new CustomException(ErrorCode.CHAT_ERROR);
+        }
       }
+    } else {
+      log.info("해당 채팅방에 클라이언트가 없습니다.");
+      throw new CustomException(ErrorCode.NOT_EXIST_CLIENT);
     }
   }
 
@@ -52,7 +70,16 @@ public class ChatWebSocketHandler implements WebSocketHandler {
   @Override
   public void afterConnectionClosed(WebSocketSession session, CloseStatus closeStatus)
       throws Exception {
-    list.remove(session);
+    Long roomId = extractRoomId(session); // 클라이언트가 속한 채팅방 ID를 추출
+
+    List<WebSocketSession> roomSessions = chatRooms.get(roomId);
+    if (roomSessions != null) {
+      roomSessions.remove(session);
+//      if (roomSessions.isEmpty()) {
+//        // 채팅방에 세션이 더 이상 없으면 채팅방 정보를 삭제를 해야할지..
+//        chatRooms.remove(roomId);
+//      }
+    }
     log.info(session + "의 클라이언트 접속 해제");
   }
 
@@ -61,5 +88,17 @@ public class ChatWebSocketHandler implements WebSocketHandler {
   @Override
   public boolean supportsPartialMessages() {
     return false;
+  }
+
+  private Long extractRoomId(WebSocketSession session) {
+    Long roomId = null;
+    String uri = Objects.requireNonNull(session.getUri()).toString();
+    String[] uriParts = uri.split("/");
+    // EX_URL) /chat/room/{roomId} 일 때 roomId 추출
+    // 늘어난다면 수 변경해주면.. (일단 임시로 설정)
+    if (uriParts.length >= 3 && uriParts[2].equals("room")) {
+      roomId = Long.valueOf(uriParts[3]);
+    }
+    return roomId;
   }
 }

--- a/src/main/java/project/newchat/common/type/ErrorCode.java
+++ b/src/main/java/project/newchat/common/type/ErrorCode.java
@@ -17,7 +17,9 @@ public enum ErrorCode {
     ROOM_USER_FULL("방에 사용자가 다 차 있습니다."),
     NONE_ROOM("현재 방이 없습니다."),
     CHAT_ERROR("채팅이 전송에 오류가 있습니다."),
-    NOT_ROOM_CREATOR("방 생성자가 아닙니다.")
+    NOT_ROOM_CREATOR("방 생성자가 아닙니다."),
+    NOT_EXIST_CLIENT("채팅방에 클라이언트가 없습니다."),
+    ALREADY_JOIN_ROOM("이미 채팅방에 입장해 있습니다.")
     ;
 
     private final String description;

--- a/src/main/java/project/newchat/common/util/ResponseUtils.java
+++ b/src/main/java/project/newchat/common/util/ResponseUtils.java
@@ -1,0 +1,51 @@
+package project.newchat.common.util;
+
+import java.util.HashMap;
+import java.util.LinkedHashMap;
+import java.util.Map;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+
+public class ResponseUtils {
+  public static ResponseEntity<Object> ok(String message, Object result) {
+    Map<String, Object> response = new LinkedHashMap<>();
+    response.put("isSuccess", true);
+    response.put("code", HttpStatus.OK.value());
+    response.put("message", message);
+    response.put("result", result);
+    return ResponseEntity.ok(response);
+  }
+
+  public static ResponseEntity<Object> ok(String message) {
+    Map<String, Object> response = new LinkedHashMap<>();
+    response.put("isSuccess", true);
+    response.put("code", HttpStatus.OK.value());
+    response.put("message", message);
+    return ResponseEntity.ok(response);
+  }
+
+  public static ResponseEntity<Object> notFound(String message) {
+    Map<String, Object> response = new LinkedHashMap<>();
+    response.put("isSuccess", false);
+    response.put("code", HttpStatus.NOT_FOUND.value());
+    response.put("message", message);
+    return ResponseEntity.status(HttpStatus.NOT_FOUND).body(response);
+  }
+
+
+  public static ResponseEntity<Object> badRequest(String message) {
+    Map<String, Object> response = new LinkedHashMap<>();
+    response.put("isSuccess", false);
+    response.put("code", HttpStatus.BAD_REQUEST.value());
+    response.put("message", message);
+    return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(response);
+  }
+
+  public static ResponseEntity<Object> serverError(String message) {
+    Map<String, Object> response = new LinkedHashMap<>();
+    response.put("isSuccess", false);
+    response.put("code", HttpStatus.INTERNAL_SERVER_ERROR.value());
+    response.put("message", message);
+    return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).body(response);
+  }
+}

--- a/src/main/java/project/newchat/user/controller/UserController.java
+++ b/src/main/java/project/newchat/user/controller/UserController.java
@@ -7,9 +7,11 @@ import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 import project.newchat.common.config.LoginCheck;
+import project.newchat.common.util.ResponseUtils;
 import project.newchat.user.domain.User;
 import project.newchat.user.domain.request.LoginRequest;
 import project.newchat.user.domain.request.UserRequest;
+import project.newchat.user.dto.UserDto;
 import project.newchat.user.service.UserService;
 
 import javax.servlet.http.HttpSession;
@@ -25,8 +27,8 @@ public class UserController {
     @PostMapping("/signUp")
     public ResponseEntity<Object> signUp(
             @RequestBody @Valid UserRequest userRequest) {
-        userService.signUp(userRequest);
-        return ResponseEntity.ok().body("success");
+        UserDto user = userService.signUp(userRequest);
+        return ResponseUtils.ok("회원가입 성공", user);
     }
 
     @PostMapping("/login")
@@ -35,13 +37,13 @@ public class UserController {
             HttpSession session) {
         User login = userService.login(userRequest);
         session.setAttribute("user", login.getId());
-        return ResponseEntity.ok().body("success");
+        return ResponseEntity.ok().body("로그인 성공");
     }
 
     @PostMapping("/logout")
     @LoginCheck
     public ResponseEntity<Object> logout(HttpSession session) {
         session.invalidate();
-        return ResponseEntity.ok().body("success");
+        return ResponseEntity.ok().body("로그아웃 성공");
     }
 }

--- a/src/main/java/project/newchat/user/dto/UserDto.java
+++ b/src/main/java/project/newchat/user/dto/UserDto.java
@@ -1,0 +1,17 @@
+package project.newchat.user.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class UserDto {
+  private String email;
+  private String nickname;
+}

--- a/src/main/java/project/newchat/user/service/UserService.java
+++ b/src/main/java/project/newchat/user/service/UserService.java
@@ -6,13 +6,16 @@ import project.newchat.user.domain.request.LoginRequest;
 import project.newchat.user.domain.request.UserRequest;
 
 import javax.servlet.http.HttpSession;
+import project.newchat.user.dto.UserDto;
 
 @Service
 public interface UserService {
-    User signUp(UserRequest user);
 
-    User login(LoginRequest user);
+  UserDto signUp(UserRequest user);
 
+  User signUpTest(UserRequest user); // 테스트 용 (dto 때문에 따로 관리)
+
+  User login(LoginRequest user);
 
 
 }

--- a/src/main/java/project/newchat/user/service/UserServiceImpl.java
+++ b/src/main/java/project/newchat/user/service/UserServiceImpl.java
@@ -8,6 +8,7 @@ import project.newchat.common.type.ErrorCode;
 import project.newchat.user.domain.User;
 import project.newchat.user.domain.request.LoginRequest;
 import project.newchat.user.domain.request.UserRequest;
+import project.newchat.user.dto.UserDto;
 import project.newchat.user.repository.UserRepository;
 
 import java.util.Optional;
@@ -19,7 +20,7 @@ public class UserServiceImpl implements UserService {
     private final UserRepository userRepository;
 
     @Override
-    public User signUp(UserRequest user) {
+    public UserDto signUp(UserRequest user) {
         Optional<User> email = userRepository.findByEmail(user.getEmail());
         if (email.isPresent()) {
             throw new CustomException(ErrorCode.ALREADY_USER_ID, user.getEmail());
@@ -30,6 +31,29 @@ public class UserServiceImpl implements UserService {
                 .nickname(user.getNickname())
                 .createdAt(LocalDateTime.now())
                 .build();
+
+        UserDto userDto = UserDto.builder()
+            .email(userSave.getEmail())
+            .nickname(userSave.getNickname())
+            .build();
+        userRepository.save(userSave);
+        return userDto;
+    }
+
+    @Override
+    public User signUpTest(UserRequest user) {
+        Optional<User> email = userRepository.findByEmail(user.getEmail());
+        if (email.isPresent()) {
+            throw new CustomException(ErrorCode.ALREADY_USER_ID, user.getEmail());
+        }
+        User userSave = User.builder()
+            .email(user.getEmail())
+            .password(user.getPassword())
+            .nickname(user.getNickname())
+            .createdAt(LocalDateTime.now())
+            .build();
+
+
         return userRepository.save(userSave);
     }
 

--- a/src/main/java/project/newchat/userchatroom/dto/UserChatRoomDto.java
+++ b/src/main/java/project/newchat/userchatroom/dto/UserChatRoomDto.java
@@ -1,0 +1,16 @@
+package project.newchat.userchatroom.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class UserChatRoomDto {
+  private Long userId;
+}

--- a/src/main/java/project/newchat/userchatroom/repository/UserChatRoomRepository.java
+++ b/src/main/java/project/newchat/userchatroom/repository/UserChatRoomRepository.java
@@ -1,5 +1,6 @@
 package project.newchat.userchatroom.repository;
 
+import java.util.List;
 import javax.persistence.LockModeType;
 import javax.persistence.QueryHint;
 import org.springframework.data.jpa.repository.JpaRepository;
@@ -24,4 +25,7 @@ public interface UserChatRoomRepository extends JpaRepository<UserChatRoom, Long
   void deleteUserChatRoomByChatRoom_Id(Long chatRoomId);
 
   void deleteUserChatRoomByUserId(Long userId);
+
+  @Query("select u.user.id from UserChatRoom u where u.chatRoom.id = ?1")
+  List<Long> findUserChatRoomByChatRoom_Id(Long chatRoomId);
 }

--- a/src/test/java/project/newchat/chatroom/service/ConcurrencyChatRoomTest.java
+++ b/src/test/java/project/newchat/chatroom/service/ConcurrencyChatRoomTest.java
@@ -18,6 +18,7 @@ import project.newchat.chatroom.domain.ChatRoom;
 import project.newchat.chatroom.repository.ChatRoomRepository;
 import project.newchat.user.domain.User;
 import project.newchat.user.domain.request.UserRequest;
+import project.newchat.user.dto.UserDto;
 import project.newchat.user.service.UserService;
 import project.newchat.userchatroom.repository.UserChatRoomRepository;
 
@@ -50,7 +51,7 @@ public class ConcurrencyChatRoomTest {
     List<User> users = new ArrayList<>();
     for (int i = 0; i < 30; i++) {
       UserRequest user = new UserRequest(i + "아이디", "12345", "test");
-      User user1 = userService.signUp(user);
+      User user1 = userService.signUpTest(user);
       users.add(user1);
     }
 

--- a/src/test/java/project/newchat/user/service/UserServiceImplTest.java
+++ b/src/test/java/project/newchat/user/service/UserServiceImplTest.java
@@ -10,6 +10,7 @@ import project.newchat.common.exception.CustomException;
 import project.newchat.user.domain.User;
 import project.newchat.user.domain.request.LoginRequest;
 import project.newchat.user.domain.request.UserRequest;
+import project.newchat.user.dto.UserDto;
 
 
 @SpringBootTest
@@ -22,10 +23,10 @@ class UserServiceImplTest {
     @DisplayName("회원가입 성공")
     void signUp_success() {
         UserRequest userRequest1 = new UserRequest("test1234@naver.com", "1234", "test");
-        User user1 = userService.signUp(userRequest1);
+        UserDto user1 = userService.signUp(userRequest1);
 
         UserRequest userRequest2 = new UserRequest("test12345@naver.com", "1234", "test");
-        User user2 = userService.signUp(userRequest2);
+        UserDto user2 = userService.signUp(userRequest2);
 
         Assertions.assertNotEquals(user1.getEmail(), user2.getEmail());
     }


### PR DESCRIPTION
### 변경사항
<!-- 이 PR에서 어떤점들이 변경되었는지 기술해주세요. 가급적이면 as-is, to-be를 활용해서 작성해주세요.  -->
**AS-IS**

- ResponseUtils Custom class를 추가하였습니다. 
controller에서 응답값(상태코드)과 성공, 실패여부와 해당 메시지 그리고 result 값을 응답하여 내려줍니다. 서비스 로직에서도 ErrorCode로 오류를 나타낼 수 있지만, 먼저 Controller에서 한번 더 체크하는 것도 맞다고 생각했습니다.
- 기존에는 채팅방 입장에서 동시성 체크는 하였으나, 1번 유저가 1번 방에 입장을 하고, 나가거나 삭제되지 않은 1번 방에 다시 입장하려고 시도했을 때, 인원수만 아니었으면 입장이 되었던 상황이었습니다.
**long type의 List 형식으로 들어가 있는 userId 값들을 불러와 List 안의 값들 중 비교하여, list 중 userId 가 있다면 들어가지 못하게 오류를 나타내게 하였습니다.**
- WebSocket 설정을 하였습니다. (아직 미완입니다만 다음 PR에서 채팅하기를 구현할 때 끝마무리 짓겠습니다.)
더불어 엔드포인트를 정확히 수정해놓겠습니다.

- 회원가입을 할 때 UserDto로 따로 빼서 응답 결과로 email, nickname을 보낼 수 있게 하였습니다.
따라서 회원가입 로직에서 DTO 클래스로 변환하여 내보내주는 로직이 추가되었는데, 추가됨에 따라 test 코드들도 변경이 생겼습니다. 동시성 체크 테스트 코드에서는 기존에 쓰였던 회원가입 메서드를 따로 테스트용도로 빼내어 사용하였습니다.

**TO-BE**

- 채팅
- WebSocket 설정

### 테스트
<!-- 본 변경사항이 테스트가 되었는지 기술해주세요 --> 
- [ ] 테스트 코드
- [x] API 테스트
