### PR TITLE
[#10] feat : 채팅 (보내기,조회 no offset)기능 추가, 방 삭제 시 채팅 내역 삭제 추가

### DIFF
--- a/src/main/java/project/newchat/chatmsg/controller/ChatMsgController.java
+++ b/src/main/java/project/newchat/chatmsg/controller/ChatMsgController.java
@@ -1,0 +1,59 @@
+package project.newchat.chatmsg.controller;
+
+
+import java.util.List;
+import javax.servlet.http.HttpSession;
+import javax.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+import project.newchat.chatmsg.domain.request.ChatMsgRequest;
+import project.newchat.chatmsg.domain.response.ChatMsgResponse;
+import project.newchat.chatmsg.dto.ChatMsgDto;
+import project.newchat.chatmsg.service.ChatMsgService;
+import project.newchat.common.config.LoginCheck;
+import project.newchat.common.util.ResponseUtils;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/chat")
+public class ChatMsgController {
+
+  private final ChatMsgService chatMsgService;
+
+  @PostMapping("/msg/{roomId}")
+  @LoginCheck
+  public ResponseEntity<Object> sendChat(
+      @PathVariable Long roomId,
+      @RequestBody @Valid ChatMsgRequest message,
+      HttpSession session) {
+    Long userId = (Long) session.getAttribute("user");
+    ChatMsgResponse response = chatMsgService.sendMessage(message, userId, roomId);
+    if (message == null) {
+      return ResponseUtils.badRequest("채팅 메시지는 공백으로 보낼 수 없습니다.");
+    } else {
+      return ResponseUtils.ok("채팅 메시지 보내기 성공", response);
+    }
+  }
+
+  @GetMapping("/msg/{roomId}")
+  @LoginCheck
+  public ResponseEntity<Object> getChatList(
+      @PathVariable Long roomId,
+      @RequestParam(required = false) Long lastId,
+      HttpSession session) {
+    Long userId = (Long) session.getAttribute("user");
+    List<ChatMsgDto> roomChatMsgList = chatMsgService.getRoomChatMsgList(roomId, userId, lastId);
+    if (roomChatMsgList != null) {
+      return ResponseUtils.ok("해당 채팅방의 메시지들을 조회하였습니다.", roomChatMsgList);
+    } else {
+      return ResponseUtils.notFound("해당 채팅방의 메시지들을 찾지 못했습니다.");
+    }
+  }
+}

--- a/src/main/java/project/newchat/chatmsg/domain/ChatMsg.java
+++ b/src/main/java/project/newchat/chatmsg/domain/ChatMsg.java
@@ -1,14 +1,20 @@
 package project.newchat.chatmsg.domain;
 
+import java.time.LocalDateTime;
+import javax.persistence.Column;
+import javax.persistence.Entity;
+import javax.persistence.FetchType;
+import javax.persistence.GeneratedValue;
+import javax.persistence.GenerationType;
+import javax.persistence.Id;
+import javax.persistence.JoinColumn;
+import javax.persistence.ManyToOne;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import project.newchat.chatroom.domain.ChatRoom;
 import project.newchat.user.domain.User;
-
-import javax.persistence.*;
-import java.time.LocalDateTime;
 
 @Entity
 @Getter

--- a/src/main/java/project/newchat/chatmsg/domain/request/ChatMsgRequest.java
+++ b/src/main/java/project/newchat/chatmsg/domain/request/ChatMsgRequest.java
@@ -1,0 +1,17 @@
+package project.newchat.chatmsg.domain.request;
+
+import javax.validation.constraints.NotEmpty;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.hibernate.validator.constraints.Length;
+
+@Getter
+@AllArgsConstructor
+@NoArgsConstructor
+public class ChatMsgRequest {
+  @NotEmpty
+  @Length(max = 300)
+  private String message;
+
+}

--- a/src/main/java/project/newchat/chatmsg/domain/response/ChatMsgResponse.java
+++ b/src/main/java/project/newchat/chatmsg/domain/response/ChatMsgResponse.java
@@ -1,0 +1,20 @@
+package project.newchat.chatmsg.domain.response;
+
+import java.time.LocalDateTime;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class ChatMsgResponse {
+  private Long roomId;
+  private String from; // 누가? (사용자)
+  private String message;
+  private LocalDateTime sendTime;
+}

--- a/src/main/java/project/newchat/chatmsg/dto/ChatMsgDto.java
+++ b/src/main/java/project/newchat/chatmsg/dto/ChatMsgDto.java
@@ -1,0 +1,19 @@
+package project.newchat.chatmsg.dto;
+
+import java.time.LocalDateTime;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+public class ChatMsgDto {
+  private Long chatMsgId;
+  private Long userId;
+  private String nickname;
+  private String message;
+  private LocalDateTime sendTime;
+}

--- a/src/main/java/project/newchat/chatmsg/repository/ChatMsgCustomRepository.java
+++ b/src/main/java/project/newchat/chatmsg/repository/ChatMsgCustomRepository.java
@@ -1,0 +1,9 @@
+package project.newchat.chatmsg.repository;
+
+
+import java.util.List;
+import project.newchat.chatmsg.domain.ChatMsg;
+
+public interface ChatMsgCustomRepository {
+  List<ChatMsg> findChatRoomIdByChatMsg(Long chatMsg, Long lastId);
+}

--- a/src/main/java/project/newchat/chatmsg/repository/ChatMsgCustomRepositoryImpl.java
+++ b/src/main/java/project/newchat/chatmsg/repository/ChatMsgCustomRepositoryImpl.java
@@ -1,0 +1,42 @@
+package project.newchat.chatmsg.repository;
+
+import java.util.List;
+import javax.persistence.EntityManager;
+import javax.persistence.TypedQuery;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
+import project.newchat.chatmsg.domain.ChatMsg;
+@Repository
+@RequiredArgsConstructor
+public class ChatMsgCustomRepositoryImpl implements ChatMsgCustomRepository{
+
+  private final EntityManager entityManager;
+
+  /*
+  select c.user_id, c.message, c.send_time
+  from chat_msg c
+  where chat_room_id = 1
+  order by c.chat_msg_id asc ;
+   */
+  @Override
+  public List<ChatMsg> findChatRoomIdByChatMsg(Long chatMsg, Long lastId) {
+    String first = "select c from ChatMsg c where c.chatRoom.id =: chatMsg order by c.id asc";
+    String paging = "select c from ChatMsg c where c.chatRoom.id =: chatMsg and c.id > :lastId order by c.id asc";
+
+    TypedQuery<ChatMsg> query = null;
+
+    if (lastId == null) {
+      query = entityManager
+          .createQuery(first, ChatMsg.class)
+          .setParameter("chatMsg", chatMsg);
+    } else {
+      query = entityManager
+          .createQuery(paging, ChatMsg.class)
+          .setParameter("chatMsg", chatMsg)
+          .setParameter("lastId", lastId);
+    }
+    return query
+        .setMaxResults(10)
+        .getResultList();
+  }
+}

--- a/src/main/java/project/newchat/chatmsg/repository/ChatMsgRepository.java
+++ b/src/main/java/project/newchat/chatmsg/repository/ChatMsgRepository.java
@@ -6,5 +6,5 @@ import project.newchat.chatmsg.domain.ChatMsg;
 
 @Repository
 public interface ChatMsgRepository extends JpaRepository<ChatMsg, Long> {
-
+  void deleteChatMsgByChatRoom_Id(Long chatRoomId);
 }

--- a/src/main/java/project/newchat/chatmsg/service/ChatMsgService.java
+++ b/src/main/java/project/newchat/chatmsg/service/ChatMsgService.java
@@ -1,0 +1,13 @@
+package project.newchat.chatmsg.service;
+
+import java.util.List;
+import project.newchat.chatmsg.domain.request.ChatMsgRequest;
+import project.newchat.chatmsg.domain.response.ChatMsgResponse;
+import project.newchat.chatmsg.dto.ChatMsgDto;
+
+public interface ChatMsgService {
+
+  ChatMsgResponse sendMessage(ChatMsgRequest message, Long userId, Long roomId);
+
+  List<ChatMsgDto> getRoomChatMsgList(Long roomId, Long userId, Long lastId);
+}

--- a/src/main/java/project/newchat/chatmsg/service/ChatMsgServiceImpl.java
+++ b/src/main/java/project/newchat/chatmsg/service/ChatMsgServiceImpl.java
@@ -1,0 +1,68 @@
+package project.newchat.chatmsg.service;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.stream.Collectors;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import project.newchat.chatmsg.domain.ChatMsg;
+import project.newchat.chatmsg.domain.request.ChatMsgRequest;
+import project.newchat.chatmsg.domain.response.ChatMsgResponse;
+import project.newchat.chatmsg.dto.ChatMsgDto;
+import project.newchat.chatmsg.repository.ChatMsgCustomRepository;
+import project.newchat.chatmsg.repository.ChatMsgRepository;
+import project.newchat.chatroom.domain.ChatRoom;
+import project.newchat.chatroom.repository.ChatRoomRepository;
+import project.newchat.common.exception.CustomException;
+import project.newchat.common.type.ErrorCode;
+import project.newchat.user.domain.User;
+import project.newchat.user.repository.UserRepository;
+
+@Service
+@RequiredArgsConstructor
+public class ChatMsgServiceImpl implements ChatMsgService {
+
+  private final ChatMsgRepository chatMsgRepository;
+  private final UserRepository userRepository;
+  private final ChatRoomRepository chatRoomRepository;
+  private final ChatMsgCustomRepository chatMsgCustomRepository;
+
+  @Override
+  public ChatMsgResponse sendMessage(ChatMsgRequest message, Long userId, Long roomId) {
+    User findUser = userRepository.findById(userId)
+        .orElseThrow(() -> new CustomException(ErrorCode.NOT_FOUND_USER));
+
+    ChatRoom chatRoom = chatRoomRepository.findChatRoomById(roomId)
+        .orElseThrow(() -> new CustomException(ErrorCode.NOT_FOUND_ROOM));
+    // 채팅 메시지 생성
+    ChatMsg chatMsg = ChatMsg.builder()
+        .message(message.getMessage())
+        .sendTime(LocalDateTime.now())
+        .user(findUser)
+        .chatRoom(chatRoom)
+        .build();
+    // Response
+    ChatMsgResponse response = ChatMsgResponse.builder()
+        .roomId(roomId)
+        .from(findUser.getNickname())
+        .message(message.getMessage())
+        .sendTime(chatMsg.getSendTime())
+        .build();
+    chatMsgRepository.save(chatMsg);
+    return response;
+  }
+
+  @Override
+  public List<ChatMsgDto> getRoomChatMsgList(Long roomId, Long userId, Long lastId) {
+    userRepository.findById(userId)
+        .orElseThrow(() -> new CustomException(ErrorCode.NOT_FOUND_USER));
+
+    List<ChatMsg> chatMsgsList = chatMsgCustomRepository.findChatRoomIdByChatMsg(roomId, lastId);
+    return chatMsgsList.stream().map(chatMsg -> new ChatMsgDto(
+        chatMsg.getId(),
+        chatMsg.getUser().getId(),
+        chatMsg.getUser().getNickname(),
+        chatMsg.getMessage(),
+        chatMsg.getSendTime())).collect(Collectors.toList());
+  }
+}

--- a/src/main/java/project/newchat/chatroom/controller/ChatRoomController.java
+++ b/src/main/java/project/newchat/chatroom/controller/ChatRoomController.java
@@ -26,6 +26,7 @@ import project.newchat.userchatroom.domain.UserChatRoom;
 @RequiredArgsConstructor
 @RequestMapping("/chat")
 public class ChatRoomController {
+
   private final ChatRoomService chatRoomService;
 
   // 방을 만든 사람이 방장임.(roomCreator 지정해주기)
@@ -37,70 +38,64 @@ public class ChatRoomController {
       HttpSession session) {
     Long userId = (Long) session.getAttribute("user");
     chatRoomService.createRoom(chatRoomRequest, userId);
-    if (userId == null) {
-      return ResponseUtils.badRequest("로그인 후에 이용해 주세요.");
-    } else {
-      return ResponseUtils.ok("채팅방을 생성하였습니다.");
-    }
+    return ResponseUtils.ok("채팅방을 생성하였습니다.");
   }
 
   // 방의 key를 통해 입장할 수 있어야 함.
   // 동시성 이슈 체크
   @PostMapping("/room/join/{roomId}")
   @LoginCheck
-  public ResponseEntity<Object> joinRoom (
+  public ResponseEntity<Object> joinRoom(
       @PathVariable Long roomId,
       HttpSession session) {
     Long userId = (Long) session.getAttribute("user");
     chatRoomService.joinRoom(roomId, userId);
-    if (userId == null) {
-      return ResponseUtils.badRequest("로그인 후에 이용해 주세요.");
-    } else {
-      return ResponseUtils.ok("해당 채팅방에 입장하였습니다.");
-    }
+    return ResponseUtils.ok("해당 채팅방에 입장하였습니다.");
   }
+
   // 전체 리스트
   @GetMapping("/room")
   @LoginCheck
-  public ResponseEntity<Object> roomList (
+  public ResponseEntity<Object> roomList(
       Pageable pageable) {
     List<ChatRoomDto> roomList = chatRoomService.getRoomList(pageable);
-    return ResponseUtils.ok("전체 목록 조회에 성공하였습니다.", roomList);
+    if (roomList.size() == 0) {
+      return ResponseUtils.notFound("현재 생성되어 있는 채팅방이 없습니다.");
+    } else {
+      return ResponseUtils.ok("전체 목록 조회에 성공하였습니다.", roomList);
+    }
   }
+
   // 사용자(자신)가 생성한 방 리스트 조회
   @GetMapping("/room/creator")
   @LoginCheck
   public ResponseEntity<Object> getByUserRoomList(
-      HttpSession session,Pageable pageable) {
+      HttpSession session, Pageable pageable) {
 
     Long userId = (Long) session.getAttribute("user");
     List<ChatRoomDto> userByRoomList = chatRoomService.roomsByCreatorUser(userId, pageable);
-
-    if (userId == null) {
-      return ResponseUtils.badRequest("로그인 후에 이용해 주세요.");
-    }
     if (userByRoomList.size() == 0) {
       return ResponseUtils.notFound("사용자(자신)가 생성한 방이 없습니다.");
     } else {
       return ResponseUtils.ok("사용자(자신)가 생성한 방 리스트 조회 성공", userByRoomList);
     }
   }
+
   // 사용자(자신)가 들어가 있는 방 리스트 조회
   @GetMapping("/room/part")
   @LoginCheck
   public ResponseEntity<Object> getByUserRoomPartList(
-      HttpSession session,Pageable pageable) {
+      HttpSession session, Pageable pageable) {
     Long userId = (Long) session.getAttribute("user");
     List<ChatRoomDto> userByRoomPartList = chatRoomService
         .getUserByRoomPartList(userId, pageable);
-    if (userId == null) {
-      return ResponseUtils.badRequest("로그인 후에 이용해 주세요.");
-    } if (userByRoomPartList.size() == 0) {
+    if (userByRoomPartList.size() == 0) {
       return ResponseUtils.notFound("사용자(자신)가 들어가 있는 방이 없습니다.");
     } else {
       return ResponseUtils.ok("사용자(자신)가 들어가 있는 방 리스트 조회 성공.", userByRoomPartList);
     }
   }
+
   // 채팅방 나가기
   @DeleteMapping("/room/out/{roomId}")
   @LoginCheck
@@ -108,12 +103,9 @@ public class ChatRoomController {
       @PathVariable Long roomId, HttpSession session) {
     Long userId = (Long) session.getAttribute("user");
     chatRoomService.outRoom(userId, roomId);
-    if (userId == null) {
-      return ResponseUtils.badRequest("로그인 후에 이용해 주세요.");
-    } else {
-      return ResponseUtils.ok("채팅방을 나갔습니다.");
-    }
+    return ResponseUtils.ok("채팅방을 나갔습니다.");
   }
+
   // 채팅방 삭제
   @DeleteMapping("/room/delete/{roomId}")
   @LoginCheck
@@ -121,10 +113,6 @@ public class ChatRoomController {
       @PathVariable Long roomId, HttpSession session) {
     Long userId = (Long) session.getAttribute("user");
     chatRoomService.deleteRoom(userId, roomId);
-    if (userId == null) {
-      return ResponseUtils.badRequest("로그인 후에 이용해 주세요.");
-    } else {
-      return ResponseUtils.ok("채팅방을 삭제했습니다.");
-    }
+    return ResponseUtils.ok("채팅방을 삭제했습니다.");
   }
 }

--- a/src/main/java/project/newchat/chatroom/repository/ChatRoomRepository.java
+++ b/src/main/java/project/newchat/chatroom/repository/ChatRoomRepository.java
@@ -12,6 +12,7 @@ import org.springframework.data.jpa.repository.QueryHints;
 import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 import project.newchat.chatroom.domain.ChatRoom;
+import project.newchat.chatroom.dto.ChatRoomDto;
 
 @Repository
 public interface ChatRoomRepository extends JpaRepository<ChatRoom, Long> {
@@ -19,6 +20,8 @@ public interface ChatRoomRepository extends JpaRepository<ChatRoom, Long> {
   @Lock(LockModeType.PESSIMISTIC_WRITE)
   @QueryHints({@QueryHint(name = "javax.persistence.lock.timeout", value ="1000")})
   Optional<ChatRoom> findById(Long aLong);
+
+  Optional<ChatRoom> findChatRoomById(Long id);
 
   @Query("select c from ChatRoom c where c.roomCreator=:userId")
   Page<ChatRoom> findAllByUserId(@Param("userId")Long userId,Pageable pageable); //

--- a/src/main/java/project/newchat/chatroom/service/ChatRoomServiceImpl.java
+++ b/src/main/java/project/newchat/chatroom/service/ChatRoomServiceImpl.java
@@ -121,14 +121,15 @@ public class ChatRoomServiceImpl implements ChatRoomService {
   @Override
   @Transactional
   public void outRoom(Long userId, Long roomId) {
-    Long roomCreatorId = chatRoomRepository
-        .findChatRoomIdByRoomId(roomId);
+    Optional<ChatRoom> roomCreatorId = chatRoomRepository
+        .findChatRoomById(roomId);
     // 방장이 아니라면
-    if (!Objects.equals(roomCreatorId, userId)) {
+    if (!Objects.equals(roomCreatorId.get().getRoomCreator(), userId)) {
       userChatRoomRepository.deleteUserChatRoomByUserId(userId);
       return;
     }
     // 방장이라면 방 삭제
+    chatMsgRepository.deleteChatMsgByChatRoom_Id(roomId);
     userChatRoomRepository.deleteUserChatRoomByChatRoom_Id(roomId);
     chatRoomRepository.deleteById(roomId);
   }
@@ -136,32 +137,18 @@ public class ChatRoomServiceImpl implements ChatRoomService {
   @Override
   @Transactional
   public void deleteRoom(Long userId, Long roomId) {
-    Long roomCreatorId = chatRoomRepository
-        .findChatRoomIdByRoomId(roomId);
-    if (!Objects.equals(roomCreatorId, userId)) {
+    Optional<ChatRoom> roomCreatorId = chatRoomRepository
+        .findChatRoomById(roomId);
+    if (!Objects.equals(roomCreatorId.get().getRoomCreator(), userId)) {
       throw new CustomException(ErrorCode.NOT_ROOM_CREATOR);
     }
+    chatMsgRepository.deleteChatMsgByChatRoom_Id(roomId);
     userChatRoomRepository.deleteUserChatRoomByChatRoom_Id(roomId);
     chatRoomRepository.deleteById(roomId);
-    // todo : 채팅 메시지 구현 시, 방 삭제할 때 메시지도 같이 삭제되는 메서드 구현
-//    chatMsgRepository.deleteById(roomId); 방 삭제 시 채팅도 다 삭제 되어야 함.
   }
 
   // 방 조회 DTO 변환 메서드 추출
   private static List<ChatRoomDto> getChatRoomDtos(Page<ChatRoom> all) {
-//    List<ChatRoomDto> chatRoomList = new ArrayList<>();
-//
-//    for (ChatRoom list : all) {
-//      ChatRoomDto dto = ChatRoomDto.builder()
-//          .id(list.getId())
-//          .title(list.getTitle())
-//          .currentUserCount((long) list.getUserChatRooms().size())
-//          .userCountMax(list.getUserCountMax())
-//          .build();
-//
-//      chatRoomList.add(dto);
-//    }
-//    return chatRoomList;
     return all.stream()
         .map(ChatRoomDto::of)
         .collect(Collectors.toList());

--- a/src/main/java/project/newchat/chatroom/service/ChatRoomServiceImpl.java
+++ b/src/main/java/project/newchat/chatroom/service/ChatRoomServiceImpl.java
@@ -121,10 +121,11 @@ public class ChatRoomServiceImpl implements ChatRoomService {
   @Override
   @Transactional
   public void outRoom(Long userId, Long roomId) {
-    Optional<ChatRoom> roomCreatorId = chatRoomRepository
-        .findChatRoomById(roomId);
+    ChatRoom room = chatRoomRepository
+        .findChatRoomById(roomId)
+        .orElseThrow(() -> new CustomException(ErrorCode.NONE_ROOM));
     // 방장이 아니라면
-    if (!Objects.equals(roomCreatorId.get().getRoomCreator(), userId)) {
+    if (!Objects.equals(room.getRoomCreator(), userId)) {
       userChatRoomRepository.deleteUserChatRoomByUserId(userId);
       return;
     }
@@ -137,9 +138,10 @@ public class ChatRoomServiceImpl implements ChatRoomService {
   @Override
   @Transactional
   public void deleteRoom(Long userId, Long roomId) {
-    Optional<ChatRoom> roomCreatorId = chatRoomRepository
-        .findChatRoomById(roomId);
-    if (!Objects.equals(roomCreatorId.get().getRoomCreator(), userId)) {
+    ChatRoom room = chatRoomRepository
+        .findChatRoomById(roomId)
+        .orElseThrow(() -> new CustomException(ErrorCode.NONE_ROOM));
+    if (!Objects.equals(room.getRoomCreator(), userId)) {
       throw new CustomException(ErrorCode.NOT_ROOM_CREATOR);
     }
     chatMsgRepository.deleteChatMsgByChatRoom_Id(roomId);

--- a/src/main/java/project/newchat/user/domain/response/UserResponse.java
+++ b/src/main/java/project/newchat/user/domain/response/UserResponse.java
@@ -1,4 +1,0 @@
-package project.newchat.user.domain.response;
-
-public class UserResponse {
-}

--- a/src/test/java/project/newchat/chatmsg/service/ChatMsgServiceImplTest.java
+++ b/src/test/java/project/newchat/chatmsg/service/ChatMsgServiceImplTest.java
@@ -1,0 +1,51 @@
+package project.newchat.chatmsg.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.transaction.annotation.Transactional;
+import project.newchat.chatmsg.domain.request.ChatMsgRequest;
+import project.newchat.chatmsg.domain.response.ChatMsgResponse;
+import project.newchat.chatroom.domain.ChatRoom;
+import project.newchat.chatroom.repository.ChatRoomRepository;
+import project.newchat.user.domain.request.UserRequest;
+import project.newchat.user.service.UserService;
+
+@SpringBootTest
+@Transactional
+class ChatMsgServiceImplTest {
+
+  @Autowired
+  private ChatMsgService chatMsgService;
+
+  @Autowired
+  private UserService userService;
+
+  @Autowired
+  private ChatRoomRepository chatRoomRepository;
+
+
+  @Test
+  @DisplayName("채팅 보내기")
+  void sendMsg_success() {
+    UserRequest user = new UserRequest("test@test.com", "1234", "test");
+    userService.signUpTest(user);
+
+    ChatRoom test = ChatRoom.builder()
+        .roomCreator(1L)
+        .title("test")
+        .userCountMax(8)
+        .build();
+    chatRoomRepository.save(test);
+
+    ChatMsgRequest message = new ChatMsgRequest("test");
+
+    ChatMsgResponse chatMsgResponse = chatMsgService.sendMessage(message, 1L, 1L);
+    assertThat(chatMsgResponse.getMessage()).isEqualTo("test");
+    assertThat(chatMsgResponse.getFrom()).isEqualTo("test");
+    assertThat(chatMsgResponse.getRoomId()).isEqualTo(1L);
+  }
+}

--- a/src/test/java/project/newchat/chatroom/service/ChatRoomServiceImplTest.java
+++ b/src/test/java/project/newchat/chatroom/service/ChatRoomServiceImplTest.java
@@ -1,13 +1,19 @@
 package project.newchat.chatroom.service;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.*;
 
+import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.transaction.annotation.Transactional;
 import project.newchat.chatroom.controller.request.ChatRoomRequest;
+import project.newchat.chatroom.domain.ChatRoom;
+import project.newchat.chatroom.repository.ChatRoomRepository;
+import project.newchat.common.exception.CustomException;
+import project.newchat.common.type.ErrorCode;
 import project.newchat.user.domain.User;
 import project.newchat.user.domain.request.LoginRequest;
 import project.newchat.user.domain.request.UserRequest;
@@ -22,6 +28,9 @@ class ChatRoomServiceImplTest {
 
   @Autowired
   private UserService userService;
+
+  @Autowired
+  private ChatRoomRepository chatRoomRepository;
 
 
   @Test
@@ -40,5 +49,28 @@ class ChatRoomServiceImplTest {
 
     assertThat(chatRoomRequest.getTitle()).isEqualTo("testTitle");
     assertThat(chatRoomRequest.getUserCountMax()).isEqualTo(8);
+  }
+  @Test
+  @DisplayName("동일 채팅방 두 번 이상 입장 시도(실패가 되어야 한다.)")
+  void continue_joinRoom_failed() {
+    UserRequest user = new UserRequest("test@test.com", "1234", "test");
+    userService.signUpTest(user);
+
+    UserRequest user2 = new UserRequest("test2@test.com", "1234", "test");
+    userService.signUpTest(user2);
+
+    ChatRoom test = ChatRoom.builder()
+        .roomCreator(1L)
+        .title("test")
+        .userCountMax(8)
+        .build();
+
+    chatRoomRepository.save(test);
+    chatRoomService.joinRoom(1L, 2L);
+
+    CustomException exception = assertThrows(CustomException.class, () ->
+        chatRoomService.joinRoom(1L, 2L));
+    assertThat(exception.getErrorCode()).isEqualTo(ErrorCode.ALREADY_JOIN_ROOM);
+    assertThat(exception.getErrorMessage()).isEqualTo("이미 채팅방에 입장해 있습니다.");
   }
 }


### PR DESCRIPTION
### 변경사항
<!-- 이 PR에서 어떤점들이 변경되었는지 기술해주세요. 가급적이면 as-is, to-be를 활용해서 작성해주세요.  -->
**AS-IS**

- 채팅을 보낼 수 있습니다.
해당 채팅방에서 채팅을 보낼 수 있습니다. 채팅 메시지를 생성 후 ChatMsgResponse 클래스로 from을 이용해 누가 보냈는지 식별할 수 있게 개발하였습니다. 
- 해당 채팅방의 채팅을 조회할 수 있습니다.
페이징을 고려했습니다. offset vs no offset 이었는데, 채팅의 경우 게시글에 비해 훨씬 많은 양의 raw가 있을 것이라 생각하고, 계속해서 조회를 할 시에 기존에 있던 읽었던 데이터는 계속 버려가면서 새로 읽어오는 방식은 손해라 생각했습니다. 물론 추가적인 코드를 작성하여 해결할 수 있겠지만 no offset을 놔 두고 할 필요는 없다 판단했습니다.
no offset은 제가 바라던 채팅 내역 조회에서 **무한 스크롤 방식**이 가장 적합했으며, 데이터를 계속 조회해도 원하는 조회값만 가져오기에 DB에 무리가 가지 않는다 생각했습니다. 구현한 방식은 이렇습니다.
1. 채팅을 제가 지정한 개수(10개)만큼 가져오도록 합니다.
2. 10개를 가져오고, 마지막 id(lastId)를 기준으로 lastId parameter를 받고 다시 조회를 시작합니다.
3. lastId를 기준으로 10개를 가져와 조회합니다.
4. 반복....

### Refactor
- 피드백을 적용하여 Controller에서 기존에 있던 @LoginCheck가 걸려 있는 API의 로그인 로직을 제거했습니다.
- 기존에 채팅방 삭제(방장만 가능), 채팅방 나가기(방장일 경우 방 삭제)에서 ChatRoom과 UserChatRoom만 삭제했었습니다.
이번에 채팅 기능을 도입하게 되면서 채팅방이 삭제가 될 경우 채팅 메시지도 삭제가 되는 것이 맞다고 생각해, 채팅 메시지도 roomId에 따라 삭제가 되게끔 변경하였습니다.
- TEST 코드는 만약 입장해 있는 상태인데, 한번 더 입장하려는 API를 요청하게 된다면 오류가 발생하여야 한다 생각하여 작성하였습니다.

#### 그리고 추가적으로...
code convention 모두 적용(아직 안 된 곳이 있습니다.)이라던지, 중복되는 코드들은 메서드로 추출하던지 할 때는 한 번에 묶어서 PR에 올리도록 하겠습니다. 기능 추가같은 PR에 같이 올리게 되면 파일 수가 급격하게 늘어나기 때문입니다..! 추후에 올려서 정리하겠습니다.

**TO-BE**

- WebSocket 설정
- 저번에 주셨던 피드백 적용(Controller에 있는 ResponseUtils 메시징 enum으로 처리)
- 채팅 WebSocket으로 server에 보내주기 

### 테스트
<!-- 본 변경사항이 테스트가 되었는지 기술해주세요 --> 
- [x] 테스트 코드
- [x] API 테스트
