### PR TITLE
[#15] feat : redis session storage 

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -28,6 +28,9 @@ dependencies {
     runtimeOnly 'com.mysql:mysql-connector-j'
     annotationProcessor 'org.projectlombok:lombok'
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
+
+    implementation 'org.springframework.boot:spring-boot-starter-data-redis'
+    implementation 'org.springframework.session:spring-session-data-redis'
 }
 
 tasks.named('test') {

--- a/src/main/java/project/newchat/NewChatApplication.java
+++ b/src/main/java/project/newchat/NewChatApplication.java
@@ -2,7 +2,9 @@ package project.newchat;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.session.data.redis.config.annotation.web.http.EnableRedisHttpSession;
 
+@EnableRedisHttpSession
 @SpringBootApplication
 public class NewChatApplication {
 

--- a/src/main/java/project/newchat/common/config/RedisConfig.java
+++ b/src/main/java/project/newchat/common/config/RedisConfig.java
@@ -1,0 +1,38 @@
+package project.newchat.common.config;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.redis.connection.RedisConnectionFactory;
+import org.springframework.data.redis.connection.RedisStandaloneConfiguration;
+import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.serializer.GenericJackson2JsonRedisSerializer;
+import org.springframework.data.redis.serializer.StringRedisSerializer;
+
+@Configuration
+public class RedisConfig {
+  @Value("${spring.redis.host}")
+  public String host;
+
+  @Value("${spring.redis.port}")
+  public int port;
+
+
+  @Bean
+  public RedisTemplate<String, Object> redisTemplate(RedisConnectionFactory connectionFactory) {
+    RedisTemplate<String, Object> redisTemplate = new RedisTemplate<>();
+    redisTemplate.setKeySerializer(new StringRedisSerializer()); // Redis 키를 문자열로 직렬화
+    redisTemplate.setValueSerializer(new GenericJackson2JsonRedisSerializer()); // 값의 직렬화를 위해 -> Redis (JSON)
+    redisTemplate.setConnectionFactory(connectionFactory); // 연결 다 된 Redis -> Factory와 연결
+    return redisTemplate;
+  }
+
+  @Bean
+  public RedisConnectionFactory redisConnectionFactory() {
+    RedisStandaloneConfiguration configuration = new RedisStandaloneConfiguration();
+    configuration.setHostName(host);
+    configuration.setPort(port);
+    return new LettuceConnectionFactory(configuration);
+  }
+}


### PR DESCRIPTION
### 변경사항
<!-- 이 PR에서 어떤점들이 변경되었는지 기술해주세요. 가급적이면 as-is, to-be를 활용해서 작성해주세요.  -->
**AS-IS**

- version2로 업그레이드 하게 되면서, scale-out/up을 생각해 보았습니다.  scale-up 방식은 저의 현재 개인 프로젝트이고, 한 대의 컴퓨터로 동작하기에 CPU, 메모리, 디스크의 수의 제한이 있으며 많은 트래픽으로부터 서버가 터질 경우를 고려해봐야 합니다. 따라서 동일한 사양의 서버를 추가하여 성능을 늘리는 방식인 scale-out을 선택하였습니다.
- 기존에는 단일 서버였으며, local session에 저장하는 방식이었습니다. 이의 방식은 서버가 내려가게 될 때 session이 다 사라질 수 있다는 것인데, 이는 꼭 필요한 개선해야할 점입니다. 서버가 내려가도 session이 남아 있을 수 있게 session storage를사용하기로 결정했습니다. 이렇게 된다면 서버가 내려가게 되어도 여러 서버가 하나의 session storage를 바라보기 때문에 문제가 되지 않습니다.
- DB와 Redis를 둘 중 고민하였으나, 후자를 선택하였습니다. 간단하게 선택한 이유를 서술하자면
1. Read/Write가 훨씬 빠릅니다.
2. 메모리에 저장하고 관리하기 때문에 I/O에 대한 부담을 덜 줄 수 있습니다.
3. 하지만 session의 안전도는 redis가 더 낮으나, 이를 보완해줄 수 있는 Replication이라는 기능을 통해 failover를 지원합니다.
4. 다른 서버(master)가 죽어도 복제 서버(slave)가 남아 있기에 가용성이 높습니다.

따라서 Redis를 선택하게 되었습니다. 혹시나 PR에 기재된 내용 중 잘못된 내용이 있다면 , 피드백해주시면 정말 감사하겠습니다.

아래는 postman으로 로그인/로그아웃을 했을 때, redis에 있는 key를 확인한 결과입니다. 로그인 로그아웃 순서로 기재합니다.

![redis_세션_스토리지_](https://github.com/yeb0/NewChat/assets/119172260/faf8627f-a846-435f-afd1-66c8a8d53e7c)
---
![redis_세션_스토리지_로그아웃_이후](https://github.com/yeb0/NewChat/assets/119172260/9de5a5d2-66e9-41ac-b206-5f045b5edb08)


**TO-BE**

- Redis로 저번에 있던 동시성문제 해결하기
- 로드밸런싱을 위해 nginx 도입 고려

### 테스트
<!-- 본 변경사항이 테스트가 되었는지 기술해주세요 --> 
- [ ] 테스트 코드
- [ ] API 테스트
