### PR TITLE
[#16] refactor : Redis를 활용한 동시성(join) 해결

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -28,6 +28,9 @@ dependencies {
     runtimeOnly 'com.mysql:mysql-connector-j'
     annotationProcessor 'org.projectlombok:lombok'
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
+
+    implementation 'org.springframework.boot:spring-boot-starter-data-redis'
+    implementation 'org.springframework.session:spring-session-data-redis'
 }
 
 tasks.named('test') {

--- a/build.gradle
+++ b/build.gradle
@@ -31,6 +31,7 @@ dependencies {
 
     implementation 'org.springframework.boot:spring-boot-starter-data-redis'
     implementation 'org.springframework.session:spring-session-data-redis'
+    implementation 'org.redisson:redisson-spring-boot-starter:3.17.7' // redis message broker(lock)
 }
 
 tasks.named('test') {

--- a/src/main/java/project/newchat/NewChatApplication.java
+++ b/src/main/java/project/newchat/NewChatApplication.java
@@ -2,7 +2,9 @@ package project.newchat;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.session.data.redis.config.annotation.web.http.EnableRedisHttpSession;
 
+@EnableRedisHttpSession
 @SpringBootApplication
 public class NewChatApplication {
 

--- a/src/main/java/project/newchat/chatroom/repository/ChatRoomRepository.java
+++ b/src/main/java/project/newchat/chatroom/repository/ChatRoomRepository.java
@@ -1,24 +1,19 @@
 package project.newchat.chatroom.repository;
 
 import java.util.Optional;
-import javax.persistence.LockModeType;
-import javax.persistence.QueryHint;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
-import org.springframework.data.jpa.repository.Lock;
 import org.springframework.data.jpa.repository.Query;
-import org.springframework.data.jpa.repository.QueryHints;
 import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 import project.newchat.chatroom.domain.ChatRoom;
-import project.newchat.chatroom.dto.ChatRoomDto;
 
 @Repository
 public interface ChatRoomRepository extends JpaRepository<ChatRoom, Long> {
 
-  @Lock(LockModeType.PESSIMISTIC_WRITE)
-  @QueryHints({@QueryHint(name = "javax.persistence.lock.timeout", value ="1000")})
+//  @Lock(LockModeType.PESSIMISTIC_WRITE)
+//  @QueryHints({@QueryHint(name = "javax.persistence.lock.timeout", value ="1000")})
   Optional<ChatRoom> findById(Long aLong);
 
   Optional<ChatRoom> findChatRoomById(Long id);

--- a/src/main/java/project/newchat/common/config/RedisConfig.java
+++ b/src/main/java/project/newchat/common/config/RedisConfig.java
@@ -1,0 +1,38 @@
+package project.newchat.common.config;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.redis.connection.RedisConnectionFactory;
+import org.springframework.data.redis.connection.RedisStandaloneConfiguration;
+import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.serializer.GenericJackson2JsonRedisSerializer;
+import org.springframework.data.redis.serializer.StringRedisSerializer;
+
+@Configuration
+public class RedisConfig {
+  @Value("${spring.redis.host}")
+  public String host;
+
+  @Value("${spring.redis.port}")
+  public int port;
+
+
+  @Bean
+  public RedisTemplate<String, Object> redisTemplate(RedisConnectionFactory connectionFactory) {
+    RedisTemplate<String, Object> redisTemplate = new RedisTemplate<>();
+    redisTemplate.setKeySerializer(new StringRedisSerializer()); // Redis 키를 문자열로 직렬화
+    redisTemplate.setValueSerializer(new GenericJackson2JsonRedisSerializer()); // 값의 직렬화를 위해 -> Redis (JSON)
+    redisTemplate.setConnectionFactory(connectionFactory); // 연결 다 된 Redis -> Factory와 연결
+    return redisTemplate;
+  }
+
+  @Bean
+  public RedisConnectionFactory redisConnectionFactory() {
+    RedisStandaloneConfiguration configuration = new RedisStandaloneConfiguration();
+    configuration.setHostName(host);
+    configuration.setPort(port);
+    return new LettuceConnectionFactory(configuration);
+  }
+}

--- a/src/main/java/project/newchat/common/type/ErrorCode.java
+++ b/src/main/java/project/newchat/common/type/ErrorCode.java
@@ -19,7 +19,9 @@ public enum ErrorCode {
   CHAT_ERROR("채팅이 전송에 오류가 있습니다."),
   NOT_ROOM_CREATOR("방 생성자가 아닙니다."),
   NOT_EXIST_CLIENT("채팅방에 클라이언트가 없습니다."),
-  ALREADY_JOIN_ROOM("이미 채팅방에 입장해 있습니다.");
+  ALREADY_JOIN_ROOM("이미 채팅방에 입장해 있습니다."),
+  FAILED_GET_LOCK("락을 획득하지 못했습니다.")
+  ;
 
   private final String description;
 }

--- a/src/main/java/project/newchat/userchatroom/repository/UserChatRoomRepository.java
+++ b/src/main/java/project/newchat/userchatroom/repository/UserChatRoomRepository.java
@@ -1,12 +1,8 @@
 package project.newchat.userchatroom.repository;
 
 import java.util.List;
-import javax.persistence.LockModeType;
-import javax.persistence.QueryHint;
 import org.springframework.data.jpa.repository.JpaRepository;
-import org.springframework.data.jpa.repository.Lock;
 import org.springframework.data.jpa.repository.Query;
-import org.springframework.data.jpa.repository.QueryHints;
 import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 import project.newchat.userchatroom.domain.UserChatRoom;
@@ -14,10 +10,9 @@ import project.newchat.userchatroom.domain.UserChatRoom;
 @Repository
 public interface UserChatRoomRepository extends JpaRepository<UserChatRoom, Long> {
 
-  @Lock(LockModeType.PESSIMISTIC_WRITE)
-  @QueryHints({@QueryHint(name = "javax.persistence.lock.timeout", value = "1000")})
+//  @Lock(LockModeType.PESSIMISTIC_WRITE)
+//  @QueryHints({@QueryHint(name = "javax.persistence.lock.timeout", value = "1000")})
   Long countByChatRoomId(Long roomId); // 비관적 락
-
   @Query("select count(*) from UserChatRoom u where u.chatRoom.id = :roomId")
   Long countNonLockByChatRoomId(@Param("roomId")Long roomId); // test 용도
 

--- a/src/test/java/project/newchat/chatroom/service/ConcurrencyChatRoomTest.java
+++ b/src/test/java/project/newchat/chatroom/service/ConcurrencyChatRoomTest.java
@@ -13,12 +13,10 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.transaction.annotation.Transactional;
 import project.newchat.chatroom.domain.ChatRoom;
 import project.newchat.chatroom.repository.ChatRoomRepository;
 import project.newchat.user.domain.User;
 import project.newchat.user.domain.request.UserRequest;
-import project.newchat.user.dto.UserDto;
 import project.newchat.user.service.UserService;
 import project.newchat.userchatroom.repository.UserChatRoomRepository;
 
@@ -41,6 +39,7 @@ public class ConcurrencyChatRoomTest {
 
   @Autowired
   private UserChatRoomRepository userChatRoomRepository;
+
   @Autowired
   private ChatRoomRepository chatRoomRepository;
 
@@ -64,11 +63,10 @@ public class ConcurrencyChatRoomTest {
 
     IntStream.range(0, 30).forEach(e -> executorService.submit(() -> {
       try {
-        // 테스트할코드
         try {
           chatRoomService.joinRoom(save.getId(), users.get(e).getId());
         } catch (Exception ex) {
-          ex.printStackTrace();
+          assertThat(ex).isNull(); // 예외 발생 시 테스트를 실패로 처리
         }
       } finally {
         countDownLatch.countDown();


### PR DESCRIPTION
### 변경사항
<!-- 이 PR에서 어떤점들이 변경되었는지 기술해주세요. 가급적이면 as-is, to-be를 활용해서 작성해주세요.  -->
**AS-IS**

- 기존에 있던 비관적 락(DB 락)을 사용했었습니다. 이번에 **Redis를 도입하게 되면서 동시성이슈를 수정**하였습니다.
아래의 글은 제가 해당 락의 사용 이유, 찾아보며 공부한 것들을 정리한 내용입니다.

제가 락의 종류에 관해서 알아본 것은 두 가지입니다. 스핀락과 분산락이 있습니다.

### 스핀락

스레드가 락을 획득하기 위해 계속해서 루프를 돌며 시도하는 방식입니다. 다른 스레드가 락을 해제할 때까지 계속해서 루프를 도는 것이 특징입니다. 빠른 응답시간과 자원 낭비의 최소화가 장점이지만 **계속해서 루프를 도는 것에 의해 Redis에 큰 부하를 줄 것**으로 예상이 갔습니다. 저의 요구사항에서는 길게 Lock을 가지고 있지는 않으나, 혹시나 길게 잡을 경우 불필요한 CPU 자원을 사용하게 될 우려가 있습니다.

### 분산락

분산 환경에서 여러 노드 사이에서 동기화를 위해 사용되는 락입니다. 분산락은 여러 노드 간에 락을 공유하고 동시에 접근을 제어하여 데이터의 일관성을 유지할 수 있습니다. 분산락은 락을 획득하는 노드가 다운되는 등의 상황에 대비하여 안전한 락 관리를 할 수 있음에 장점이 있습니다. 하지만 단점이 있습니다만, 성능적인 큰 이슈 그런 것이 아니라 따로 라이브러리를 추가적으로 공부를 할 필요가 있다는 것입니다. 그만큼 복잡하기에 잘 알고 사용하는 것이 중요하다 생각합니다. 

추가적으로, 스핀락에 비해 tryLock 메서드 시그니처를 보면 leaseTime을 통해서 Lock을 반납하게 됩니다. 스핀락의 루프방식이 아닌 메시징(반납했다는)을 줌과 동시에 차례대로 진행이 되어 **Redis에 큰 부하를 주지 않을 수 있다**는 것입니다. 이러한 점들을 고려해 분산락(Redisson)을 사용하는 것을 결정하였습니다.

**@Transactional() 격리수준 설정 ?**

가장 강한 격리수준인 SERIALIZABLE도 생각해보았으나, 격리 수준은 강력했지만 성능이 너무 떨어져서 배제하였습니다. 격리수준은 필요하였기에 가장 낮은 READ_UNCOMMITTED 속성을 걸어두었습니다. 필요한 이유는, 동시성을 우선시 했으며 lock 반납은 finally 블록을 사용함으로써 예외 발생여부와 관계없이 정확하게 lock을 반납할 수 있기 때문입니다. 분산 락과 @Transactional을 활용하여 동시성과 데이터 일관성을 관리하는 접근 방식은 데이터베이스 트랜잭션보다는 경량화된 동시성 제어를 위한 방식으로 사용했습니다.

하지만 Redis 서버에 장애가 일어났을 경우를 생각해보면 이 때 **Redis 클러스터를 사용하면** 이의 문제도 해결할 수 있다 생각합니다.

작성하다 보니 글이 길어졌습니다. 혹시나 잘못된 부분이나 틀렸다면 바르게 지적해 주신다면 감사하겠습니다.

---

브랜치를 해당 PR 이전의 브랜치를 따서 push를 했는데 이전 PR(Redis session storage)의 file이 같이 올라온 것 같습니다.. 나중에 merge 하고 나서 정리해놓겠습니다.

**TO-BE**

- 만약 서버에 트래픽이 몰린다는 것을 가정해, 로드 밸런싱을 위해 nginx 도입할 예정입니다.

### 테스트
<!-- 본 변경사항이 테스트가 되었는지 기술해주세요 --> 
- [x] 테스트 코드
- [x] API 테스트
