### PR TITLE
[#17] refactor : 회원가입 비밀번호 암호화 및 login service 수정

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -32,6 +32,11 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-data-redis'
     implementation 'org.springframework.session:spring-session-data-redis'
     implementation 'org.redisson:redisson-spring-boot-starter:3.17.7' // redis message broker(lock)
+    // Tomcat 의존성 추가
+    runtimeOnly 'org.springframework.boot:spring-boot-starter-tomcat'
+    runtimeOnly 'org.mariadb.jdbc:mariadb-java-client'
+    // security password 암호화
+    implementation 'org.springframework.security:spring-security-crypto:5.7.1'
 }
 
 tasks.named('test') {

--- a/src/main/java/project/newchat/common/config/SecurityConfig.java
+++ b/src/main/java/project/newchat/common/config/SecurityConfig.java
@@ -1,0 +1,14 @@
+package project.newchat.common.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.crypto.factory.PasswordEncoderFactories;
+import org.springframework.security.crypto.password.PasswordEncoder;
+
+@Configuration
+public class SecurityConfig {
+  @Bean
+  public PasswordEncoder passwordEncoder() {
+    return PasswordEncoderFactories.createDelegatingPasswordEncoder();
+  }
+}

--- a/src/main/java/project/newchat/common/type/ErrorCode.java
+++ b/src/main/java/project/newchat/common/type/ErrorCode.java
@@ -20,7 +20,8 @@ public enum ErrorCode {
   NOT_ROOM_CREATOR("방 생성자가 아닙니다."),
   NOT_EXIST_CLIENT("채팅방에 클라이언트가 없습니다."),
   ALREADY_JOIN_ROOM("이미 채팅방에 입장해 있습니다."),
-  FAILED_GET_LOCK("락을 획득하지 못했습니다.")
+  FAILED_GET_LOCK("락을 획득하지 못했습니다."),
+  NOT_SAME_PASSWORD("비밀번호 불일치")
   ;
 
   private final String description;

--- a/src/main/java/project/newchat/user/controller/UserController.java
+++ b/src/main/java/project/newchat/user/controller/UserController.java
@@ -11,6 +11,7 @@ import project.newchat.common.type.ResponseMessage;
 import project.newchat.common.util.ResponseUtils;
 import project.newchat.user.domain.User;
 import project.newchat.user.domain.request.LoginRequest;
+import project.newchat.user.domain.request.TestUserRequest;
 import project.newchat.user.domain.request.UserRequest;
 import project.newchat.user.dto.UserDto;
 import project.newchat.user.service.UserService;
@@ -29,6 +30,13 @@ public class UserController {
   public ResponseEntity<Object> signUp(
       @RequestBody @Valid UserRequest userRequest) {
     UserDto user = userService.signUp(userRequest);
+    return ResponseUtils.ok(ResponseMessage.CREATE_USER, user);
+  }
+
+  @PostMapping("/signUp2") // 서버 터트리기 테스트
+  public ResponseEntity<Object> signUpTest(
+      @RequestBody @Valid TestUserRequest userRequest) {
+    UserDto user = userService.signUpTe2(userRequest);
     return ResponseUtils.ok(ResponseMessage.CREATE_USER, user);
   }
 

--- a/src/main/java/project/newchat/user/domain/User.java
+++ b/src/main/java/project/newchat/user/domain/User.java
@@ -1,11 +1,11 @@
 package project.newchat.user.domain;
 
+import java.io.Serializable;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import project.newchat.chatmsg.domain.ChatMsg;
-import project.newchat.chatroom.domain.ChatRoom;
 import project.newchat.userchatroom.domain.UserChatRoom;
 
 import javax.persistence.*;
@@ -17,7 +17,7 @@ import java.util.List;
 @Builder
 @NoArgsConstructor
 @AllArgsConstructor
-public class User {
+public class User implements Serializable {
 
   @Id
   @GeneratedValue(strategy = GenerationType.IDENTITY)

--- a/src/main/java/project/newchat/user/domain/request/TestUserRequest.java
+++ b/src/main/java/project/newchat/user/domain/request/TestUserRequest.java
@@ -1,0 +1,25 @@
+package project.newchat.user.domain.request;
+
+import javax.validation.constraints.Email;
+import javax.validation.constraints.NotEmpty;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.hibernate.validator.constraints.Length;
+
+@Getter
+@AllArgsConstructor
+@NoArgsConstructor
+public class TestUserRequest {
+
+//  @Email // email 형식
+//  @NotEmpty // valid 유효성(String 은 Empty, 다른 타입은 NotNull)
+//  @Length(min = 4, max = 20) // 길이 제한 (입력값이 포함하지 않는 경우 오류)
+  private String email;
+  @NotEmpty
+  @Length(min = 4, max = 20)
+  private String password;
+  @NotEmpty
+  @Length(min = 4, max = 20)
+  private String nickname;
+}

--- a/src/main/java/project/newchat/user/service/UserService.java
+++ b/src/main/java/project/newchat/user/service/UserService.java
@@ -3,6 +3,7 @@ package project.newchat.user.service;
 import org.springframework.stereotype.Service;
 import project.newchat.user.domain.User;
 import project.newchat.user.domain.request.LoginRequest;
+import project.newchat.user.domain.request.TestUserRequest;
 import project.newchat.user.domain.request.UserRequest;
 
 import javax.servlet.http.HttpSession;
@@ -13,7 +14,9 @@ public interface UserService {
 
   UserDto signUp(UserRequest user);
 
-  User signUpTest(UserRequest user); // 테스트 용 (dto 때문에 따로 관리)
+  User signUpTest(UserRequest user);
+
+  UserDto signUpTe2(TestUserRequest test);
 
   User login(LoginRequest user);
 


### PR DESCRIPTION
### 변경사항
<!-- 이 PR에서 어떤점들이 변경되었는지 기술해주세요. 가급적이면 as-is, to-be를 활용해서 작성해주세요.  -->
**AS-IS**

- 기존에는 회원가입 시에 입력했던 비밀번호가 그대로 DB에 저장되어 보안 상 큰 위험이 있다 판단했습니다.
따라서 비밀번호 암호화를 진행하기 위해 제가 알아본 방법은 두 가지였습니다.

>Spring security를 사용해서 암호화를 할지, SHA512, salt를 사용해서 암호화를 진행할지 고민이었습니다. 전자의 경우, 안전한 해시 알고리즘과 salt 자동관리가 되어 후자에 비해 미리 구현이 되어 있다는 점입니다. 후자의 경우는 제가 직접 설정하여 구현을 진행할 수 있다는 점인데, 첫 번째로 제가 해당 부분을 구현을 어설프게 할 경우에 보안에 취약해진다는 점입니다. 두 번째로, 유지보수와 꾸준한 업데이트가 필요합니다. 보안에 취약해질 경우 개발자가 계속해서 업데이트를 해줘야 한다는 단점이 존재합니다.

따라서 Spring security의 기능 중 비밀번호 암호화를 위한 BCrypt 알고리즘(PasswordEncoder)을 이용하여 암호화를 진행합니다.

- User class에 Serializable 인터페이스를 구현했습니다.
해당 오류로 인해 구현하게 되었는데, 오류는 아래와 같습니다.
>failed to deserialize payload. is the byte array a result of corresponding serialization for defaultdeserializer?; nested exception is org.springframework.core.nestedioexception: failed to deserialize object type; nested exception is java.lang.classnotfoundexception: org.springframework.security.web.csrf.defaultcsrftoken
> org.springframework.data.redis.serializer.SerializationException: Cannot deserialize;

**역직렬화를 할 수 없다는 내용이었습니다**. redis와 관련되어 security와 어떠한 연관된 문제를 일으킨 건지는 잘 모르겠습니다.. 해결하기 위해 User 부분에 해당 인터페이스를 구현해 직렬화를 가능케 하였습니다. 
저의 짤막한 지식으로 추론해 보자면.. user 객체를 직렬화하여 어디론가(서버?redis?..)에 데이터를 전송하기 위함으로, 기존(구현하기 전)에는 security가 막고 있어서 보낼 수 없었다면, 구현하게 됨으로써 보낼 수 있게 됐지 않았을까 싶습니다. 
자세한 원인과 이유에 대해서는 계속해서 찾아봐야겠습니다. 찾게 되면 이 PR에 기록으로 comment 남겨 놓겠습니다! 

- 마지막으로, 서버 터트리기(서버 부하테스트)에 관한 로직이 있는데, 이 부분에 관해서는 회원가입(user email 난수로 돌림)을 통해 트래픽을 줌으로써 서버의 부하를 줄 수 있었습니다. 
![스크린샷 2023-05-21 164939](https://github.com/yeb0/NewChat/assets/119172260/70bb8d99-f886-457a-bf89-063d2ccc950d)
속도와 에러율을 해결하기 위해 로드 밸런서(Nginx 고려 중)를 도입하려 합니다.

+++
공부 필독
- salt에 대해 필독!!!! + 암호화 방식 doc 참고하여 공부하기
- 이번 문제점(직렬,역직렬) 파악

**TO-BE**

- 회원 수정
- 채팅방 제목 수정
- PR에 있던 해당 문제점, 이유 파악

### 테스트
<!-- 본 변경사항이 테스트가 되었는지 기술해주세요 --> 
- [ ] 테스트 코드
- [x] API 테스트
