### PR TITLE
[#23] feat : 친구 목록 조회 기능 추가

### DIFF
--- a/src/main/java/project/newchat/friend/controller/FriendController.java
+++ b/src/main/java/project/newchat/friend/controller/FriendController.java
@@ -4,6 +4,7 @@ package project.newchat.friend.controller;
 import java.util.List;
 import javax.servlet.http.HttpSession;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Pageable;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -14,6 +15,8 @@ import project.newchat.common.config.LoginCheck;
 import project.newchat.common.type.ResponseMessage;
 import project.newchat.common.util.ResponseUtils;
 import project.newchat.friend.domain.Friend;
+import project.newchat.friend.dto.FriendDto;
+import project.newchat.friend.repository.FriendRepository;
 import project.newchat.friend.service.FriendService;
 
 @RestController
@@ -21,6 +24,8 @@ import project.newchat.friend.service.FriendService;
 public class FriendController {
 
   private final FriendService friendService;
+
+  private final FriendRepository friendRepository;
 
   @PostMapping("/friend/{toUserId}")
   @LoginCheck
@@ -62,5 +67,19 @@ public class FriendController {
     Long fromUserId = (Long) session.getAttribute("user");
     friendService.delete(fromUserId, toUserId);
     return ResponseUtils.ok(ResponseMessage.FRIEND_DELETE_SUCCESS);
+  }
+  @GetMapping("/friend")
+  @LoginCheck
+  public ResponseEntity<Object> selectList(
+      Pageable pageable,
+      HttpSession session) {
+    Long fromUserId = (Long) session.getAttribute("user");
+    Long currentFriendCnt = friendRepository // controller에서 먼저 끊어주기 위함.
+        .countByFromUserIdOrToUserIdAndAccept(fromUserId);
+    if (currentFriendCnt == 0) {
+      return ResponseUtils.notFound(ResponseMessage.NOT_EXIST_FRIEND_LIST);
+    }
+    List<FriendDto> list = friendService.selectFriendList(fromUserId, pageable);
+    return ResponseUtils.friendSelectOk(ResponseMessage.FRIENDS_SELECT_SUCCESS, list, currentFriendCnt);
   }
 }

--- a/src/main/java/project/newchat/friend/repository/FriendRepository.java
+++ b/src/main/java/project/newchat/friend/repository/FriendRepository.java
@@ -1,5 +1,6 @@
 package project.newchat.friend.repository;
 
+import java.util.List;
 import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
@@ -10,9 +11,12 @@ import project.newchat.friend.domain.Friend;
 @Repository
 public interface FriendRepository extends JpaRepository<Friend, Long> {
   Optional<Friend> findByFromUserIdAndToUserId(Long fromUserId, Long toUserId);
-
   Optional<Friend> findByFromUserIdAndToUserIdAndAccept(Long fromUserId, Long toUserId, Boolean accept);
 
   @Query(value = "select count(*) from friend where (from_user_id = :id or to_user_id = :id) and accept = true", nativeQuery = true)
   Long countByFromUserIdOrToUserIdAndAccept(@Param("id") Long id);
+  // fromUserId 로 toUserId 값을 찾아낼 것 (자신의 ID가 들어가야함.)
+  List<Friend> findFriendByFromUserIdAndAccept(Long fromUserId, Boolean accept);
+  // toUserId 로 fromUserId 값을 찾아낼 것 (자신의 ID가 들어가야함.)
+  List<Friend> findFriendByToUserIdAndAccept(Long toUserId, Boolean accept);
 }

--- a/src/main/java/project/newchat/friend/service/FriendService.java
+++ b/src/main/java/project/newchat/friend/service/FriendService.java
@@ -1,5 +1,9 @@
 package project.newchat.friend.service;
 
+import java.util.List;
+import org.springframework.data.domain.Pageable;
+import project.newchat.friend.dto.FriendDto;
+
 public interface FriendService {
 
   void addFriend(Long fromUserId, Long toUserId);
@@ -9,4 +13,6 @@ public interface FriendService {
   void refuse(Long fromUserId, Long toUserId);
 
   void delete(Long fromUserId, Long toUserId);
+
+  List<FriendDto> selectFriendList(Long fromUserId, Pageable pageable);
 }

--- a/src/main/java/project/newchat/user/repository/UserRepository.java
+++ b/src/main/java/project/newchat/user/repository/UserRepository.java
@@ -1,8 +1,11 @@
 package project.newchat.user.repository;
 
+import java.util.List;
 import java.util.Optional;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import project.newchat.user.domain.User;
 
 public interface UserRepository extends JpaRepository<User, Long> {
@@ -10,4 +13,7 @@ public interface UserRepository extends JpaRepository<User, Long> {
   Optional<User> findByEmail(String email);
 
   Optional<User> findUserByEmailAndPassword(String email, String password);
+
+  @Query("select u from User u where u.id in (:ids)")
+  List<User> findNicknameById(@Param("ids") List<Long> ids, Pageable pageable);
 }


### PR DESCRIPTION
### 변경사항
<!-- 이 PR에서 어떤점들이 변경되었는지 기술해주세요. 가급적이면 as-is, to-be를 활용해서 작성해주세요.  -->
**AS-IS**

- 친구 목록 조회 기능 추가
row가 하나로 구성되어 있어, **내가 친구추가해서 친구가 된 case, 또다른 유저가 나를 친구추가해서 친구가 된 case** 총 두 가지의 경우로 이루어져 있습니다. 따라서, fromUserId 와 toUserId 값에 각각 자신의 id값을 넣고, 결과값에서 나와 친구가 된 유저들의 id값들을 가져옵니다. 그 list 형식의 id값들을 다시 findNicknameById 메서드에 넣어 결과를 가져옵니다.

처음에는 in절을 사용하지 않아 for문을 돌면서 있는 유저 수만큼 쿼리가 날아가게 되었습니다. N+1문제라기보단 로직의 문제점이었는데, 이를 해결하기 위하여 findNicknameById 메서드의 쿼리를 in 절 (id값들 - list)로 인해 하나의 쿼리로 줄이게 되었습니다.

controller에서 repository를 의존합니다. 기존에는 list의 size 값으로 response에 내려주었으나, service단이 끝나고 나서 값을 가져 오게 됩니다. 그리고 친구 수가 0일 경우, service 로직을 가서 쿼리 몇 개 날릴 일도 없이 바로 0의 값을 보내주고 return하면 되기 때문입니다.

**TO-BE**

- 로그인 상태 추가
- 조회 기능 성능 생각해보기

### 테스트
<!-- 본 변경사항이 테스트가 되었는지 기술해주세요 --> 
- [ ] 테스트 코드
- [x] API 테스트
