### PR TITLE
[#24] refactor : 유저 로그인 상태 필드 추가 및 조회 추가

### DIFF
--- a/src/main/java/project/newchat/friend/dto/FriendDto.java
+++ b/src/main/java/project/newchat/friend/dto/FriendDto.java
@@ -13,4 +13,5 @@ import lombok.Setter;
 @Builder
 public class FriendDto {
   private String nickname; // 친구 닉네임
+  private Boolean status; // 친구 로그인 상태
 }

--- a/src/main/java/project/newchat/friend/repository/FriendRepository.java
+++ b/src/main/java/project/newchat/friend/repository/FriendRepository.java
@@ -6,6 +6,7 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
+import org.springframework.transaction.annotation.Transactional;
 import project.newchat.friend.domain.Friend;
 
 @Repository

--- a/src/main/java/project/newchat/friend/service/FriendServiceImpl.java
+++ b/src/main/java/project/newchat/friend/service/FriendServiceImpl.java
@@ -262,13 +262,14 @@ public class FriendServiceImpl implements FriendService {
       Long friendId = friend.getFromUserId();
       ids.add(friendId);
     }
-    List<User> userList = userRepository.findNicknameById(ids, pageable);
+    List<User> userList = userRepository.findUserById(ids, pageable);
     if (userList.isEmpty()) {
       throw new CustomException(NOT_FOUND_USER);
     }
     for (User value : userList) {
       FriendDto build = FriendDto.builder()
           .nickname(value.getNickname())
+          .status(value.getStatus())
           .build();
       friendDtoList.add(build);
     }

--- a/src/main/java/project/newchat/user/controller/UserController.java
+++ b/src/main/java/project/newchat/user/controller/UserController.java
@@ -1,5 +1,10 @@
 package project.newchat.user.controller;
 
+import static project.newchat.common.type.ResponseMessage.CREATE_USER;
+import static project.newchat.common.type.ResponseMessage.LOGIN_SUCCESS;
+import static project.newchat.common.type.ResponseMessage.LOGOUT_SUCCESS;
+import static project.newchat.common.type.ResponseMessage.USER_UPDATE_SUCCESS;
+
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.PatchMapping;
@@ -32,14 +37,14 @@ public class UserController {
   public ResponseEntity<Object> signUp(
       @RequestBody @Valid UserRequest userRequest) {
     UserDto user = userService.signUp(userRequest);
-    return ResponseUtils.ok(ResponseMessage.CREATE_USER, user);
+    return ResponseUtils.ok(CREATE_USER, user);
   }
 
   @PostMapping("/signUp2") // 서버 터트리기 테스트
   public ResponseEntity<Object> signUpTest(
       @RequestBody @Valid TestUserRequest userRequest) {
     UserDto user = userService.signUpTe2(userRequest);
-    return ResponseUtils.ok(ResponseMessage.CREATE_USER, user);
+    return ResponseUtils.ok(CREATE_USER, user);
   }
 
   @PostMapping("/login")
@@ -48,14 +53,16 @@ public class UserController {
       HttpSession session) {
     User login = userService.login(userRequest);
     session.setAttribute("user", login.getId());
-    return ResponseUtils.ok(ResponseMessage.LOGIN_SUCCESS);
+    return ResponseUtils.ok(LOGIN_SUCCESS);
   }
 
   @PostMapping("/logout")
   @LoginCheck
   public ResponseEntity<Object> logout(HttpSession session) {
+    Long userId = (Long) session.getAttribute("user");
+    userService.logout(userId);
     session.invalidate();
-    return ResponseUtils.ok(ResponseMessage.LOGOUT_SUCCESS);
+    return ResponseUtils.ok(LOGOUT_SUCCESS);
   }
 
   @PatchMapping("/update")
@@ -65,6 +72,6 @@ public class UserController {
       HttpSession session) {
     Long userId = (Long) session.getAttribute("user");
     userService.update(userId, updateRequest);
-    return ResponseUtils.ok(ResponseMessage.USER_UPDATE_SUCCESS);
+    return ResponseUtils.ok(USER_UPDATE_SUCCESS);
   }
 }

--- a/src/main/java/project/newchat/user/domain/User.java
+++ b/src/main/java/project/newchat/user/domain/User.java
@@ -37,17 +37,13 @@ public class User {
 
   private LocalDateTime updatedAt;
 
+  private Boolean status; // 로그인이면 true, 로그아웃 false
+
   @OneToMany(mappedBy = "user", fetch = FetchType.LAZY)
   private List<UserChatRoom> userChatRooms;
 
   @OneToMany(mappedBy = "user", fetch = FetchType.LAZY)
   private List<ChatMsg> chatMsgs;
-
-//  @OneToMany(mappedBy = "fromUser", fetch = FetchType.LAZY)
-//  private List<Friend> fromUsers;
-//
-//  @OneToMany(mappedBy = "toUser", fetch = FetchType.LAZY)
-//  private List<Friend> toUsers;
 
   public void update(String nickname, LocalDateTime updatedAt) {
     this.setNickname(nickname);

--- a/src/main/java/project/newchat/user/repository/UserRepository.java
+++ b/src/main/java/project/newchat/user/repository/UserRepository.java
@@ -14,6 +14,6 @@ public interface UserRepository extends JpaRepository<User, Long> {
 
   Optional<User> findUserByEmailAndPassword(String email, String password);
 
-  @Query("select u from User u where u.id in (:ids)")
-  List<User> findNicknameById(@Param("ids") List<Long> ids, Pageable pageable);
+  @Query("select u from User u where u.id in (:ids) order by u.status desc ")
+  List<User> findUserById(@Param("ids") List<Long> ids, Pageable pageable);
 }

--- a/src/main/java/project/newchat/user/service/UserService.java
+++ b/src/main/java/project/newchat/user/service/UserService.java
@@ -23,4 +23,7 @@ public interface UserService {
 
 
   void update(Long userId, UpdateRequest updateRequest);
+
+  void logout(Long userId);
+
 }


### PR DESCRIPTION
### 변경사항
<!-- 이 PR에서 어떤점들이 변경되었는지 기술해주세요. 가급적이면 as-is, to-be를 활용해서 작성해주세요.  -->
**AS-IS**

- 유저 로그인 상태 추가 및 친구 목록 조회에서 상태 추가
USER 단에서 status 필드를 추가해 true false 로 나뉘어 상태를 알아볼 수 있게 추가하였습니다. 친구 목록에서 조회하게 될 때 온라인(true)인 상태와 오프라인(false)상태를 나뉘어 조회하게 됩니다. 온라인부터 나올 수 있게 order by status desc를 통해 정렬해 두었습니다.

**TO-BE**

- 채팅방 내의 유저 목록 조회

### 테스트
<!-- 본 변경사항이 테스트가 되었는지 기술해주세요 --> 
- [ ] 테스트 코드
- [x] API 테스트
