### PR TITLE
[#29] Kafka Producer, Consumer 도입

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -37,6 +37,8 @@ dependencies {
     runtimeOnly 'org.mariadb.jdbc:mariadb-java-client'
     // security password 암호화
     implementation 'org.springframework.security:spring-security-crypto:5.7.1'
+    // kafka
+    implementation 'org.springframework.kafka:spring-kafka'
 }
 
 tasks.named('test') {

--- a/src/main/java/project/newchat/chatmsg/service/ChatMsgServiceImpl.java
+++ b/src/main/java/project/newchat/chatmsg/service/ChatMsgServiceImpl.java
@@ -17,7 +17,7 @@ import project.newchat.chatmsg.repository.ChatMsgRepository;
 import project.newchat.chatroom.domain.ChatRoom;
 import project.newchat.chatroom.repository.ChatRoomRepository;
 import project.newchat.common.exception.CustomException;
-import project.newchat.common.type.ErrorCode;
+import project.newchat.common.kafka.Producers;
 import project.newchat.user.domain.User;
 import project.newchat.user.repository.UserRepository;
 
@@ -29,6 +29,9 @@ public class ChatMsgServiceImpl implements ChatMsgService {
   private final UserRepository userRepository;
   private final ChatRoomRepository chatRoomRepository;
   private final ChatMsgCustomRepository chatMsgCustomRepository;
+
+  private final String BASIC_TOPIC = "CHAT_ROOM";
+  private final Producers producers;
 
   @Override
   public ChatMsgResponse sendMessage(ChatMsgRequest message, Long userId, Long roomId) {
@@ -52,6 +55,8 @@ public class ChatMsgServiceImpl implements ChatMsgService {
         .sendTime(chatMsg.getSendTime())
         .build();
     chatMsgRepository.save(chatMsg);
+    String topicName = BASIC_TOPIC + chatRoom.getId();
+    producers.produceMessage(topicName, message.getMessage());
     return response;
   }
 

--- a/src/main/java/project/newchat/chatroom/controller/ChatRoomController.java
+++ b/src/main/java/project/newchat/chatroom/controller/ChatRoomController.java
@@ -17,7 +17,6 @@ import java.util.List;
 import javax.servlet.http.HttpSession;
 import javax.validation.Valid;
 import lombok.RequiredArgsConstructor;
-import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.DeleteMapping;
@@ -53,8 +52,8 @@ public class ChatRoomController {
       @RequestBody @Valid ChatRoomRequest chatRoomRequest,
       HttpSession session) {
     Long userId = (Long) session.getAttribute("user");
-    chatRoomService.createRoom(chatRoomRequest, userId);
-    return ResponseUtils.ok(CREATE_CHAT_ROOM_SUCCESS);
+    ChatRoom room = chatRoomService.createRoom(chatRoomRequest, userId);
+    return ResponseUtils.ok(CREATE_CHAT_ROOM_SUCCESS, room.getCreatedAt());
   }
 
   // 방의 key를 통해 입장할 수 있어야 함.
@@ -82,6 +81,7 @@ public class ChatRoomController {
           .ok(CHAT_ROOM_ALL_BY_LIST_SELECT_SUCCESS, roomList);
     }
   }
+
   // 전체 리스트에서 좋아요 순으로 정렬
   @GetMapping("/room/heart")
   @LoginCheck
@@ -159,6 +159,7 @@ public class ChatRoomController {
     chatRoomService.deleteRoom(userId, roomId);
     return ResponseUtils.ok(DELETE_CHAT_ROOM_SUCCESS);
   }
+
   // 방에 누가 있는지 조회 (최대 8명 제한이니, 페이징 처리는 X)
   @GetMapping("/room/users/{roomId}")
   @LoginCheck
@@ -175,7 +176,7 @@ public class ChatRoomController {
   public ResponseEntity<Object> getMyHeartRoomList(
       Pageable pageable, HttpSession session) {
     Long userId = (Long) session.getAttribute("user");
-    List<ChatRoomDto> list =  chatRoomService.myHeartRoomList(userId, pageable);
+    List<ChatRoomDto> list = chatRoomService.myHeartRoomList(userId, pageable);
     if (list.size() == 0) {
       return ResponseUtils.notFound(NOT_EXIST_CHAT_ROOM);
     }

--- a/src/main/java/project/newchat/chatroom/service/ChatRoomService.java
+++ b/src/main/java/project/newchat/chatroom/service/ChatRoomService.java
@@ -1,17 +1,17 @@
 package project.newchat.chatroom.service;
 
 import java.util.List;
-import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import project.newchat.chatroom.controller.request.ChatRoomRequest;
 import project.newchat.chatroom.controller.request.ChatRoomUpdateRequest;
+import project.newchat.chatroom.domain.ChatRoom;
 import project.newchat.chatroom.dto.ChatRoomDto;
 import project.newchat.chatroom.dto.ChatRoomUserDto;
 
 public interface ChatRoomService {
 
 
-  void createRoom(ChatRoomRequest chatRoomRequest, Long userId);
+  ChatRoom createRoom(ChatRoomRequest chatRoomRequest, Long userId);
 
   void joinRoom(Long roomId, Long userId);
 

--- a/src/main/java/project/newchat/common/handler/ChatWebSocketHandler.java
+++ b/src/main/java/project/newchat/common/handler/ChatWebSocketHandler.java
@@ -9,6 +9,7 @@ import java.util.Objects;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Component;
 import org.springframework.web.socket.CloseStatus;
+import org.springframework.web.socket.TextMessage;
 import org.springframework.web.socket.WebSocketHandler;
 import org.springframework.web.socket.WebSocketMessage;
 import org.springframework.web.socket.WebSocketSession;
@@ -100,5 +101,14 @@ public class ChatWebSocketHandler implements WebSocketHandler {
       roomId = Long.valueOf(uriParts[4]);
     }
     return roomId;
+  }
+
+  public void sendMessage(String payload) throws Exception {
+    for (List<WebSocketSession> sessions : chatRooms.values()) {
+      for (WebSocketSession session : sessions) {
+        TextMessage msg = new TextMessage(payload);
+        session.sendMessage(msg);
+      }
+    }
   }
 }

--- a/src/main/java/project/newchat/common/kafka/Consumers.java
+++ b/src/main/java/project/newchat/common/kafka/Consumers.java
@@ -1,0 +1,27 @@
+package project.newchat.common.kafka;
+
+import java.util.HashMap;
+import java.util.Map;
+import lombok.RequiredArgsConstructor;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.kafka.annotation.KafkaListener;
+import org.springframework.messaging.handler.annotation.Payload;
+import org.springframework.stereotype.Component;
+import project.newchat.chatmsg.domain.ChatMsg;
+
+@Component
+@RequiredArgsConstructor
+public class Consumers {
+  private final Logger logger = LoggerFactory.getLogger(Consumers.class);
+  @KafkaListener(topics = "${spring.kafka.template.default-topic}",
+      groupId = "${spring.kafka.consumer.group-id}")
+  public void consume(@Payload ChatMsg chatMsg) throws Exception {
+    logger.info("Consume msg : roomId : '{}', nickname :'{}', sender : '{}' ",
+        chatMsg.getId(), chatMsg.getUser().getNickname(), chatMsg.getMessage());
+    Map<String, String> msg = new HashMap<>();
+    msg.put("roomNum", String.valueOf(chatMsg.getChatRoom().getId()));
+    msg.put("message", chatMsg.getMessage());
+    msg.put("sender", chatMsg.getUser().getNickname());
+  }
+}

--- a/src/main/java/project/newchat/common/kafka/Producers.java
+++ b/src/main/java/project/newchat/common/kafka/Producers.java
@@ -1,0 +1,21 @@
+package project.newchat.common.kafka;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.kafka.core.KafkaTemplate;
+import org.springframework.stereotype.Component;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class Producers {
+  private final Logger logger = LoggerFactory.getLogger(Producers.class);
+  private final KafkaTemplate<String, String> kafkaTemplate;
+
+  public void produceMessage(String topic, String payload) {
+    logger.info("Topic : '{}' to Payload : '{}'", topic, payload);
+    kafkaTemplate.send(topic, payload);
+  }
+}

--- a/src/main/java/project/newchat/common/kafka/config/KafkaConsumerConfig.java
+++ b/src/main/java/project/newchat/common/kafka/config/KafkaConsumerConfig.java
@@ -1,0 +1,50 @@
+package project.newchat.common.kafka.config;
+
+import java.util.HashMap;
+import java.util.Map;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.kafka.clients.consumer.ConsumerConfig;
+import org.apache.kafka.common.serialization.StringDeserializer;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.kafka.annotation.EnableKafka;
+import org.springframework.kafka.config.ConcurrentKafkaListenerContainerFactory;
+import org.springframework.kafka.core.ConsumerFactory;
+import org.springframework.kafka.core.DefaultKafkaConsumerFactory;
+
+@Slf4j
+@EnableKafka
+@Configuration
+public class KafkaConsumerConfig {
+  @Value("${spring.kafka.bootstrap-servers}")
+  private String bootstrapServer;
+  @Value("${spring.kafka.consumer.group-id}")
+  private String groupId;
+  @Value("${spring.kafka.consumer.auto-offset-reset}")
+  private String autoOffsetReset;
+  @Value("${spring.kafka.consumer.enable-auto-commit}")
+  private String enableAutoCommit;
+  @Value("${spring.kafka.consumer.max-poll-records}")
+  private String maxPollRecords;
+
+  @Bean
+  public ConsumerFactory<String, String> consumerFactory() {
+    Map<String, Object> props = new HashMap<>();
+    props.put(ConsumerConfig.BOOTSTRAP_SERVERS_CONFIG, bootstrapServer);
+    props.put(ConsumerConfig.GROUP_ID_CONFIG, groupId);
+    props.put(ConsumerConfig.KEY_DESERIALIZER_CLASS_CONFIG, StringDeserializer.class);
+    props.put(ConsumerConfig.VALUE_DESERIALIZER_CLASS_CONFIG, StringDeserializer.class);
+    props.put(ConsumerConfig.MAX_POLL_RECORDS_CONFIG, maxPollRecords);
+    props.put(ConsumerConfig.AUTO_OFFSET_RESET_CONFIG, autoOffsetReset);
+    props.put(ConsumerConfig.ENABLE_AUTO_COMMIT_CONFIG, enableAutoCommit);
+    return new DefaultKafkaConsumerFactory<>(props);
+  }
+  @Bean
+  public ConcurrentKafkaListenerContainerFactory<String, String> kafkaListenerContainerFactory() {
+    ConcurrentKafkaListenerContainerFactory<String, String> factory =
+        new ConcurrentKafkaListenerContainerFactory<>();
+    factory.setConsumerFactory(consumerFactory());
+    return factory;
+  }
+}

--- a/src/main/java/project/newchat/common/kafka/config/KafkaProducerConfig.java
+++ b/src/main/java/project/newchat/common/kafka/config/KafkaProducerConfig.java
@@ -1,0 +1,30 @@
+package project.newchat.common.kafka.config;
+
+import java.util.HashMap;
+import java.util.Map;
+import org.apache.kafka.clients.producer.ProducerConfig;
+import org.apache.kafka.common.serialization.StringSerializer;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.kafka.core.DefaultKafkaProducerFactory;
+import org.springframework.kafka.core.KafkaTemplate;
+import org.springframework.kafka.core.ProducerFactory;
+
+@Configuration
+public class KafkaProducerConfig {
+  @Value("${spring.kafka.bootstrap-servers}")
+  private String bootstrapServer;
+  @Bean
+  public ProducerFactory<String, String> producerFactory() {
+    Map<String, Object> configProps = new HashMap<>();
+    configProps.put(ProducerConfig.BOOTSTRAP_SERVERS_CONFIG, bootstrapServer);
+    configProps.put(ProducerConfig.KEY_SERIALIZER_CLASS_CONFIG, StringSerializer.class);
+    configProps.put(ProducerConfig.VALUE_SERIALIZER_CLASS_CONFIG, StringSerializer.class);
+    return new DefaultKafkaProducerFactory<>(configProps);
+  }
+  @Bean
+  public KafkaTemplate<String, String> kafkaTemplate() {
+    return new KafkaTemplate<>(producerFactory());
+  }
+}


### PR DESCRIPTION
### 변경사항
<!-- 이 PR에서 어떤점들이 변경되었는지 기술해주세요. 가급적이면 as-is, to-be를 활용해서 작성해주세요.  -->
**AS-IS**

- Kafka 도입
Producer, Consumer 그리고 Config 로 기존에 있던 ChatRoom, ChatMsg의 변경사항이 생겼습니다.

Topic은 Room 생성 시에 같이 생성되며, Join하게 될 경우 해당 Room의 Topic을 구독하게 됩니다. 해당 채팅방에 채팅을 보내는 경우엔 이미 해당 채팅방에 대해 Subscribe중이기 때문에 해당 채팅방의 유저들에게 채팅을 보냄과 동시에 방 유저들은 해당 채팅을 볼 수 있게 되었습니다.

Partitions은 동기의 작업을 위해 1로 설정하였습니다. 2이상의 Partitions를 두게 된다면 Kafka 내부적으로 비동기 처리 작업으로 인해 순서를 보장할 수 없기 때문입니다. 따라서 후자에 비해 속도는 조금 느릴지라도 순서를 보장하기 위해 위와 같이 설정하였습니다.

그리고 Logger을 통해 로깅으로 topic과 그의 message를 볼 수 있게끔 처리하였습니다.
![image](https://github.com/yeb0/NewChat/assets/119172260/1a0c9f72-a2a4-4984-8af4-805d70f6ae91)

아래는 커맨드 툴을 이용하여 실시간으로 해당 topic에 record 값이 들어왔음을 확인하였습니다.
![image](https://github.com/yeb0/NewChat/assets/119172260/a26bfb86-e7b8-43b8-80c7-11ab4c8976e2)


**TO-BE**

### **중요합니다. 꼭 생각해볼 것들**

- Kafka 구현한 것에 대해 조금 더 Refactor 할 것이 있는지 생각해볼 것
- Topic은 과연 무한대로 생성해도 괜찮은 것인지 생각해볼 것
- 만약, 어느정도 한계가 있고 부하가 있다면 topic을 1개로 설정하여 key 값은 roomId를 이용해 record를 거르는 작업을 해 볼 것.(WebSocket에서 이미 걸러진 데이터)
- Topic에 있는 record 값들은 계속 남아있어도 괜찮은지 ? 
- 만약, 삭제해야된다면 batch를 이용해서 주기적으로 삭제해야하는가 ? 

### 테스트
<!-- 본 변경사항이 테스트가 되었는지 기술해주세요 --> 
- [ ] 테스트 코드
- [ ] API 테스트
