### PR TITLE
[#30] feat : 채팅방 비밀번호 방 기능 추가 및 채팅방 나가기 refactor

### DIFF
--- a/src/main/java/project/newchat/chatroom/controller/ChatRoomController.java
+++ b/src/main/java/project/newchat/chatroom/controller/ChatRoomController.java
@@ -61,10 +61,10 @@ public class ChatRoomController {
   @PostMapping("/room/join/{roomId}")
   @LoginCheck
   public ResponseEntity<Object> joinRoom(
-      @PathVariable Long roomId,
+      @PathVariable Long roomId, @RequestBody ChatRoomRequest chatRoomRequest,
       HttpSession session) {
     Long userId = (Long) session.getAttribute("user");
-    chatRoomService.joinRoom(roomId, userId);
+    chatRoomService.joinRoom(roomId, userId, chatRoomRequest);
     return ResponseUtils.ok(JOIN_CHAT_ROOM_SUCCESS);
   }
 

--- a/src/main/java/project/newchat/chatroom/controller/request/ChatRoomRequest.java
+++ b/src/main/java/project/newchat/chatroom/controller/request/ChatRoomRequest.java
@@ -20,6 +20,6 @@ public class ChatRoomRequest {
   @NotNull
   @Max(8)
   private Integer userCountMax;
-
-
+  @Length(min = 4, max = 20)
+  private String password;
 }

--- a/src/main/java/project/newchat/chatroom/domain/ChatRoom.java
+++ b/src/main/java/project/newchat/chatroom/domain/ChatRoom.java
@@ -36,6 +36,10 @@ public class ChatRoom {
 
     private Integer userCountMax; // 최대 인원 8명
 
+    private String password;
+
+    private Boolean isPrivate;
+
 
     @OneToMany(mappedBy = "chatRoom", fetch = FetchType.LAZY)
     private List<UserChatRoom> userChatRooms;

--- a/src/main/java/project/newchat/chatroom/service/ChatRoomService.java
+++ b/src/main/java/project/newchat/chatroom/service/ChatRoomService.java
@@ -13,7 +13,7 @@ public interface ChatRoomService {
 
   ChatRoom createRoom(ChatRoomRequest chatRoomRequest, Long userId);
 
-  void joinRoom(Long roomId, Long userId);
+  void joinRoom(Long roomId, Long userId, ChatRoomRequest chatRoomRequest);
 
   List<ChatRoomDto> getRoomList(Pageable pageable);
 

--- a/src/main/java/project/newchat/common/type/ErrorCode.java
+++ b/src/main/java/project/newchat/common/type/ErrorCode.java
@@ -36,7 +36,9 @@ public enum ErrorCode {
   NOT_ROOM_MEMBER("채팅방에 속한 유저가 아닙니다."),
   ALREADY_HEART_TO_ROOM("이미 해당 채팅방에 좋아요를 누르셨습니다."),
   NOT_EXIST_ROOM_HEART("해당 채팅방에 좋아요가 눌러져 있지 않습니다."),
-  NOT_FOUND_HEART("좋아요 누른 채팅방이 없습니다.")
+  NOT_FOUND_HEART("좋아요 누른 채팅방이 없습니다."),
+  ROOM_PASSWORD_MISMATCH("방 비밀번호 불일치"),
+  NEED_TO_PASSWORD("비밀번호를 입력해 주세요.")
   ;
 
   private final String description;

--- a/src/main/java/project/newchat/userchatroom/repository/UserChatRoomRepository.java
+++ b/src/main/java/project/newchat/userchatroom/repository/UserChatRoomRepository.java
@@ -10,9 +10,6 @@ import project.newchat.userchatroom.domain.UserChatRoom;
 @Repository
 public interface UserChatRoomRepository extends JpaRepository<UserChatRoom, Long> {
 
-//  @Lock(LockModeType.PESSIMISTIC_WRITE)
-//  @QueryHints({@QueryHint(name = "javax.persistence.lock.timeout", value = "1000")})
-  Long countByChatRoomId(Long roomId); // 비관적 락
   @Query("select count(*) from UserChatRoom u where u.chatRoom.id = :roomId")
   Long countNonLockByChatRoomId(@Param("roomId")Long roomId); // test 용도
 
@@ -24,4 +21,6 @@ public interface UserChatRoomRepository extends JpaRepository<UserChatRoom, Long
   List<Long> findUserChatRoomByChatRoom_Id(Long chatRoomId);
 
   List<UserChatRoom> findUserChatRoomByChatRoomId(Long roomId);
+
+  List<UserChatRoom> findUserByChatRoomId(Long roomId);
 }

--- a/src/test/java/project/newchat/chatroom/service/ChatRoomServiceImplTest.java
+++ b/src/test/java/project/newchat/chatroom/service/ChatRoomServiceImplTest.java
@@ -44,7 +44,7 @@ class ChatRoomServiceImplTest {
 
     Long id = login.getId();
 
-    ChatRoomRequest chatRoomRequest = new ChatRoomRequest("testTitle", 8);
+    ChatRoomRequest chatRoomRequest = new ChatRoomRequest("testTitle", 8, null);
     chatRoomService.createRoom(chatRoomRequest, id);
 
     assertThat(chatRoomRequest.getTitle()).isEqualTo("testTitle");
@@ -66,10 +66,10 @@ class ChatRoomServiceImplTest {
         .build();
 
     chatRoomRepository.save(test);
-    chatRoomService.joinRoom(1L, 2L);
+    chatRoomService.joinRoom(1L, 2L, null);
 
     CustomException exception = assertThrows(CustomException.class, () ->
-        chatRoomService.joinRoom(1L, 2L));
+        chatRoomService.joinRoom(1L, 2L, null));
     assertThat(exception.getErrorCode()).isEqualTo(ErrorCode.ALREADY_JOIN_ROOM);
     assertThat(exception.getErrorMessage()).isEqualTo("이미 채팅방에 입장해 있습니다.");
   }

--- a/src/test/java/project/newchat/chatroom/service/ConcurrencyChatRoomTest.java
+++ b/src/test/java/project/newchat/chatroom/service/ConcurrencyChatRoomTest.java
@@ -64,7 +64,7 @@ public class ConcurrencyChatRoomTest {
     IntStream.range(0, 30).forEach(e -> executorService.submit(() -> {
       try {
         try {
-          chatRoomService.joinRoom(save.getId(), users.get(e).getId());
+          chatRoomService.joinRoom(save.getId(), users.get(e).getId(), null);
         } catch (Exception ex) {
           assertThat(ex).isNull(); // 예외 발생 시 테스트를 실패로 처리
         }


### PR DESCRIPTION
### 변경사항
<!-- 이 PR에서 어떤점들이 변경되었는지 기술해주세요. 가급적이면 as-is, to-be를 활용해서 작성해주세요.  -->
**AS-IS**

- 채팅방 비밀번호 방 기능 추가
채팅방에 비밀번호 방인지 아닌지 true/false로 나눌 수 있습니다. true일 경우 방을 생성할 때 비밀번호를 4자 이상 20자 이하 걸어두어 생성합니다. 다른 유저들은 해당 채팅방에 들어올 때 비밀번호와 함께 요청을 보내면, 들어올 수 있게 처리하였습니다.

- 채팅방 나가기 refactor
기존에는 현재 방에 누가 있는지 체크를 하지 않았던 로직이었습니다. 하지만 이는 문제가 되었는데, 이미 나간 방에 한번 더 API 호출을 할 경우에도 Exception이 나오지 않고 성공했다는 것이었습니다. 본래, 기존에는 요청을 보낼 수 없어야 하는데 오류가 나타나지 않아서입니다. 
따라서 현재 방에 누가 있는지 체크를 한 후, Long Type으로 List에 userId들을 담아 비교 후에 없다면 잘못된 요청이라 보내주도록 처리하였습니다. 

추가적으로 Delete 연산이 제대로 동작하지 않는다 생각하여 이것저것 구글링했었는데, 실제로 Delete 연산이 동작하지 않는 경우가 꽤나 있는 것 같아 찾아볼 수 있었습니다.  그리고 Delete 연산이 어떻게 흘러가는지 찾아보면 좋을 거 같다 생각합니다.

**TO-BE**

- Test Code 작성 및 기존 코드 Refactor
- 채팅방 제목 검색 기능

### 테스트
<!-- 본 변경사항이 테스트가 되었는지 기술해주세요 --> 
- [ ] 테스트 코드
- [x] API 테스트
