### PR TITLE
[#31] refactor : ChatMsg 조회 기능 수

### DIFF
--- a/src/main/java/project/newchat/chatmsg/dto/ChatMsgDto.java
+++ b/src/main/java/project/newchat/chatmsg/dto/ChatMsgDto.java
@@ -2,6 +2,7 @@ package project.newchat.chatmsg.dto;
 
 import java.time.LocalDateTime;
 import lombok.AllArgsConstructor;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
@@ -10,6 +11,7 @@ import lombok.Setter;
 @Setter
 @NoArgsConstructor
 @AllArgsConstructor
+@Builder
 public class ChatMsgDto {
   private Long chatMsgId;
   private Long userId;

--- a/src/main/java/project/newchat/chatroom/service/ChatRoomServiceImpl.java
+++ b/src/main/java/project/newchat/chatroom/service/ChatRoomServiceImpl.java
@@ -1,6 +1,7 @@
 package project.newchat.chatroom.service;
 
 
+import static java.time.LocalDateTime.now;
 import static project.newchat.common.type.ErrorCode.ALREADY_JOIN_ROOM;
 import static project.newchat.common.type.ErrorCode.FAILED_GET_LOCK;
 import static project.newchat.common.type.ErrorCode.INVALID_REQUEST;
@@ -14,11 +15,9 @@ import static project.newchat.common.type.ErrorCode.NOT_ROOM_MEMBER;
 import static project.newchat.common.type.ErrorCode.REQUEST_SAME_AS_CURRENT_TITLE;
 import static project.newchat.common.type.ErrorCode.ROOM_PASSWORD_MISMATCH;
 
-import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
-import java.util.Optional;
 import java.util.concurrent.TimeUnit;
 import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
@@ -76,8 +75,8 @@ public class ChatRoomServiceImpl implements ChatRoomService {
         .roomCreator(findUser.getId())
         .title(chatRoomRequest.getTitle())
         .userCountMax(chatRoomRequest.getUserCountMax())
-        .createdAt(LocalDateTime.now())
-        .updatedAt(LocalDateTime.now())
+        .createdAt(now())
+        .updatedAt(now())
         .isPrivate(false)
         .build();
     if (password != null) {
@@ -90,6 +89,7 @@ public class ChatRoomServiceImpl implements ChatRoomService {
     UserChatRoom userChatRoom = UserChatRoom.builder()
         .user(findUser)
         .chatRoom(save)
+        .joinDt(now())
         .build();
     // save
     userChatRoomRepository.save(userChatRoom);
@@ -143,6 +143,7 @@ public class ChatRoomServiceImpl implements ChatRoomService {
         UserChatRoom userChatRoom = UserChatRoom.builder()
             .user(findUser)
             .chatRoom(chatRoom)
+            .joinDt(now())
             .build();
         UserChatRoom save = userChatRoomRepository.save(userChatRoom);
         String topicName = BASIC_TOPIC + save.getChatRoom().getId();
@@ -246,7 +247,7 @@ public class ChatRoomServiceImpl implements ChatRoomService {
     if (currentRoomTitle.equals(chatRoomUpdateRequest.getTitle())) {
       throw new CustomException(REQUEST_SAME_AS_CURRENT_TITLE);
     }
-    room.update(chatRoomUpdateRequest.getTitle(), LocalDateTime.now());
+    room.update(chatRoomUpdateRequest.getTitle(), now());
     chatRoomRepository.save(room);
   }
 

--- a/src/main/java/project/newchat/userchatroom/domain/UserChatRoom.java
+++ b/src/main/java/project/newchat/userchatroom/domain/UserChatRoom.java
@@ -1,5 +1,6 @@
 package project.newchat.userchatroom.domain;
 
+import java.time.LocalDateTime;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
@@ -29,4 +30,6 @@ public class UserChatRoom {
   @ManyToOne(fetch = FetchType.LAZY)
   @JoinColumn(name = "chat_room_id")
   private ChatRoom chatRoom;
+
+  private LocalDateTime joinDt;
 }

--- a/src/main/java/project/newchat/userchatroom/repository/UserChatRoomRepository.java
+++ b/src/main/java/project/newchat/userchatroom/repository/UserChatRoomRepository.java
@@ -1,6 +1,7 @@
 package project.newchat.userchatroom.repository;
 
 import java.util.List;
+import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
@@ -23,4 +24,6 @@ public interface UserChatRoomRepository extends JpaRepository<UserChatRoom, Long
   List<UserChatRoom> findUserChatRoomByChatRoomId(Long roomId);
 
   List<UserChatRoom> findUserByChatRoomId(Long roomId);
+
+  Optional<UserChatRoom> findByUserId(Long userId);;
 }


### PR DESCRIPTION
### 변경사항
<!-- 이 PR에서 어떤점들이 변경되었는지 기술해주세요. 가급적이면 as-is, to-be를 활용해서 작성해주세요.  -->
**AS-IS**

- 채팅 조회 변경
기존에는 **채팅이 게시글처럼 조회**를 하는 식이었습니다. 

이는 무슨 말이냐면, 채팅방에서 채팅을 이용하던 중 다른 유저가 들어오게 되면 이전 채팅들을 조회할 수 있었다는 것입니다.

하지만 제 생각에는 지금까지도 운영되고 있는 채팅의 방식들 중 채팅조회는 중간에 들어오게 되면 그 부분부터 조회할 수 있기에 
Refactor 해야한다 생각했습니다.

1. 처음은 Query를 이용하여 해결하려 시도했습니다. 
하지만 이의 문제는 바로 where 절에서 문제가 발생했습니다. 조회를 하려면 where 절에 userId 값도 같이 넣어주어야 조회가 가능하기 때문입니다. userId 1번만을 조회하면 1번 유저만 조회가 되고, 2번이라면 2번만 조회가 되기에 문제가 되었습니다.
그래서 IN 절도 생각을 해 보았으나, 들어왔다 나갔다 하는 작업들이 많아지다 보면 성능적으로 좋지 못할 거 같다 생각해서 배제했습니다.

2. 그렇다면 Query 말고 **Java로 해결**해야겠다고 결정했습니다. 
UserChatRoom entity에서 joinDt와 ChatMsg entity에서 메시지를 보낸 시간 sendTime을 서로 비교해서 넣어주면 되지 않을까 생각했습니다.
Builder 패턴을 이용해서 ROW를 하나씩 담고 마지막으로 List에 add 하기 전에 joinDt와 sendTime을 비교해 순차적으로 담아주는 것을 선택했습니다. 

API TEST 로 그 결과 1번 유저가 먼저 채팅방에 채팅을 보낸 후, 2번 유저가 들어왔을 때 해당 채팅방의 채팅 내역 조회는 보이지 않았습니다.

제가 원했던 채팅 내역 조회의 결과값을 얻을 수 있었습니다.

**TO-BE**

- Test Code
- Kafka Refactor

### 테스트
<!-- 본 변경사항이 테스트가 되었는지 기술해주세요 --> 
- [ ] 테스트 코드
- [x] API 테스트
