### PR TITLE
[#32] feat : 채팅방 제목 검색 기능 추가

### DIFF
--- a/src/main/java/project/newchat/chatroom/controller/ChatRoomController.java
+++ b/src/main/java/project/newchat/chatroom/controller/ChatRoomController.java
@@ -1,5 +1,6 @@
 package project.newchat.chatroom.controller;
 
+import static project.newchat.common.type.ErrorCode.NEED_TO_INPUT_TITLE;
 import static project.newchat.common.type.ResponseMessage.CHAT_ROOM_ALL_BY_LIST_SELECT_SUCCESS;
 import static project.newchat.common.type.ResponseMessage.CHAT_ROOM_USERS_SELECT_SUCCESS;
 import static project.newchat.common.type.ResponseMessage.CHAT_ROOM_USER_SELF_BY_LIST_SELECT_SUCCESS;
@@ -26,6 +27,7 @@ import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 import project.newchat.chatroom.controller.request.ChatRoomRequest;
 import project.newchat.chatroom.controller.request.ChatRoomUpdateRequest;
@@ -34,6 +36,7 @@ import project.newchat.chatroom.dto.ChatRoomDto;
 import project.newchat.chatroom.dto.ChatRoomUserDto;
 import project.newchat.chatroom.service.ChatRoomService;
 import project.newchat.common.config.LoginCheck;
+import project.newchat.common.exception.CustomException;
 import project.newchat.common.util.ResponseUtils;
 
 
@@ -180,6 +183,18 @@ public class ChatRoomController {
     if (list.size() == 0) {
       return ResponseUtils.notFound(NOT_EXIST_CHAT_ROOM);
     }
+    return ResponseUtils.ok(CHAT_ROOM_ALL_BY_LIST_SELECT_SUCCESS, list);
+  }
+
+  @GetMapping("/room/search")
+  @LoginCheck
+  public ResponseEntity<Object> searchRoomName(
+      @RequestParam(name = "roomName") String roomName
+      , HttpSession session, Pageable pageable) {
+    Long userId = (Long) session.getAttribute("user");
+    if (roomName.isEmpty()) throw new CustomException(NEED_TO_INPUT_TITLE);
+    List<ChatRoomDto> list = chatRoomService
+        .searchRoomByTitle(roomName, userId, pageable);
     return ResponseUtils.ok(CHAT_ROOM_ALL_BY_LIST_SELECT_SUCCESS, list);
   }
 }

--- a/src/main/java/project/newchat/chatroom/repository/ChatRoomRepository.java
+++ b/src/main/java/project/newchat/chatroom/repository/ChatRoomRepository.java
@@ -29,4 +29,7 @@ public interface ChatRoomRepository extends JpaRepository<ChatRoom, Long> {
 
   @Query("SELECT c FROM ChatRoom c WHERE c.id IN :ids ORDER BY c.createdAt DESC")
   Page<ChatRoom> findChatRoomByInId(@Param("ids") List<Long> ids, Pageable pageable);
+
+  @Query("SELECT c FROM ChatRoom c WHERE c.title LIKE CONCAT('%', :title, '%')")
+  Page<ChatRoom> findChatRoomWithPartOfTitle(@Param("title") String title, Pageable pageable);
 }

--- a/src/main/java/project/newchat/chatroom/service/ChatRoomService.java
+++ b/src/main/java/project/newchat/chatroom/service/ChatRoomService.java
@@ -33,4 +33,6 @@ public interface ChatRoomService {
   List<ChatRoomUserDto> getRoomUsers(Long roomId, Long userId);
 
   List<ChatRoomDto> myHeartRoomList(Long userId, Pageable pageable);
+
+  List<ChatRoomDto> searchRoomByTitle(String roomName, Long userId, Pageable pageable);
 }

--- a/src/main/java/project/newchat/chatroom/service/ChatRoomServiceImpl.java
+++ b/src/main/java/project/newchat/chatroom/service/ChatRoomServiceImpl.java
@@ -18,6 +18,7 @@ import static project.newchat.common.type.ErrorCode.ROOM_PASSWORD_MISMATCH;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
+import java.util.Optional;
 import java.util.concurrent.TimeUnit;
 import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
@@ -299,6 +300,31 @@ public class ChatRoomServiceImpl implements ChatRoomService {
     List<ChatRoom> chatRoomList = chatRoomByInId.toList();
     List<ChatRoomDto> chatRoomDtos = new ArrayList<>();
     for (ChatRoom chatRoom : chatRoomList) {
+      ChatRoomDto build = ChatRoomDto.builder()
+          .id(chatRoom.getId())
+          .title(chatRoom.getTitle())
+          .heartCount(chatRoom.getHearts().size())
+          .currentUserCount((long) chatRoom.getUserChatRooms().size())
+          .userCountMax(chatRoom.getUserCountMax())
+          .build();
+      chatRoomDtos.add(build);
+    }
+    return chatRoomDtos;
+  }
+
+  @Override
+  @Transactional(readOnly = true)
+  public List<ChatRoomDto> searchRoomByTitle(String roomName, Long userId, Pageable pageable) {
+    getUser(userId);
+    Page<ChatRoom> search = chatRoomRepository.findChatRoomWithPartOfTitle(roomName, pageable);
+
+    List<ChatRoom> searchRoomList = search.toList();
+    List<ChatRoomDto> chatRoomDtos = new ArrayList<>();
+    if (searchRoomList.size() == 0) {
+      throw new CustomException(NOT_FOUND_ROOM);
+    }
+
+    for (ChatRoom chatRoom : searchRoomList) {
       ChatRoomDto build = ChatRoomDto.builder()
           .id(chatRoom.getId())
           .title(chatRoom.getTitle())

--- a/src/main/java/project/newchat/common/type/ErrorCode.java
+++ b/src/main/java/project/newchat/common/type/ErrorCode.java
@@ -38,7 +38,8 @@ public enum ErrorCode {
   NOT_EXIST_ROOM_HEART("해당 채팅방에 좋아요가 눌러져 있지 않습니다."),
   NOT_FOUND_HEART("좋아요 누른 채팅방이 없습니다."),
   ROOM_PASSWORD_MISMATCH("방 비밀번호 불일치"),
-  NEED_TO_PASSWORD("비밀번호를 입력해 주세요.")
+  NEED_TO_PASSWORD("비밀번호를 입력해 주세요."),
+  NEED_TO_INPUT_TITLE("검색에 필요한 채팅방 제목을 입력해 주세요.")
   ;
 
   private final String description;

--- a/src/test/java/project/newchat/chatroom/service/ChatRoomServiceImplTest.java
+++ b/src/test/java/project/newchat/chatroom/service/ChatRoomServiceImplTest.java
@@ -3,14 +3,17 @@ package project.newchat.chatroom.service;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.*;
 
+import java.util.List;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.data.domain.Pageable;
 import org.springframework.transaction.annotation.Transactional;
 import project.newchat.chatroom.controller.request.ChatRoomRequest;
 import project.newchat.chatroom.domain.ChatRoom;
+import project.newchat.chatroom.dto.ChatRoomDto;
 import project.newchat.chatroom.repository.ChatRoomRepository;
 import project.newchat.common.exception.CustomException;
 import project.newchat.common.type.ErrorCode;


### PR DESCRIPTION
### 변경사항
<!-- 이 PR에서 어떤점들이 변경되었는지 기술해주세요. 가급적이면 as-is, to-be를 활용해서 작성해주세요.  -->
**AS-IS**

- 채팅방 제목 검색 기능 추가 
채팅방 제목 검색 기능을 추가하였습니다. hibernate 버전 이슈로 인해, JPA 메서드 시그니처 중 LIKE 문(StartingWith 등등)에서 escape 키워드도 같이 자동으로 나갔었습니다. 현재 버전 이슈로 인해서 그렇게 나간다고 하는데, hibernate의 버전을 낮췄다간 다른 원인을 알 수 없는 문제가 추가적으로 발생할 것을 우려해 JPQL로 작성하여 (concat()함수) 처리했습니다.

**TO-BE**

- Kafka Refactor

### 테스트
<!-- 본 변경사항이 테스트가 되었는지 기술해주세요 --> 
- [ ] 테스트 코드
- [x] API 테스트
